### PR TITLE
fix: Added trailing option to debouncer

### DIFF
--- a/packages/pacer/src/debouncer.ts
+++ b/packages/pacer/src/debouncer.ts
@@ -22,7 +22,7 @@ export interface DebouncerOptions {
 const defaultOptions: Required<DebouncerOptions> = {
   leading: false,
   wait: 0,
-  trailing: true, // Add trailing option with default
+  trailing: true,
 }
 
 /**

--- a/packages/pacer/src/debouncer.ts
+++ b/packages/pacer/src/debouncer.ts
@@ -12,11 +12,17 @@ export interface DebouncerOptions {
    * Defaults to 0ms
    */
   wait: number
+  /**
+   * Whether to execute on the trailing edge of the timeout.
+   * Defaults to true.
+   */
+  trailing?: boolean
 }
 
 const defaultOptions: Required<DebouncerOptions> = {
   leading: false,
   wait: 0,
+  trailing: true, // Add trailing option with default
 }
 
 /**
@@ -85,7 +91,10 @@ export class Debouncer<
     // Set new timeout that will reset canLeadingExecute
     this.timeoutId = setTimeout(() => {
       this.canLeadingExecute = true
-      this.executeFunction(...args)
+      // Execute trailing only if enabled
+      if (this.options.trailing) {
+        this.executeFunction(...args)
+      }
     }, this.options.wait)
   }
 

--- a/packages/pacer/tests/debouncer.test.ts
+++ b/packages/pacer/tests/debouncer.test.ts
@@ -152,7 +152,6 @@ describe('Debouncer', () => {
     const debouncer = new Debouncer(mockFn, {
       wait: 1000,
       leading: true,
-      trailing: true
     })
 
     expect(debouncer.getExecutionCount()).toBe(0)

--- a/packages/pacer/tests/debouncer.test.ts
+++ b/packages/pacer/tests/debouncer.test.ts
@@ -68,6 +68,7 @@ describe('Debouncer', () => {
     const debouncer = new Debouncer(mockFn, {
       wait: 1000,
       leading: true,
+      trailing: false,
     })
 
     debouncer.maybeExecute('test')
@@ -83,6 +84,7 @@ describe('Debouncer', () => {
     const debouncer = new Debouncer(mockFn, {
       wait: 1000,
       leading: true,
+      trailing: false,
     })
 
     // First call - executes immediately
@@ -150,6 +152,7 @@ describe('Debouncer', () => {
     const debouncer = new Debouncer(mockFn, {
       wait: 1000,
       leading: true,
+      trailing: true
     })
 
     expect(debouncer.getExecutionCount()).toBe(0)
@@ -209,6 +212,7 @@ describe('debounce helper function', () => {
     const debouncedFn = debounce(mockFn, {
       wait: 1000,
       leading: true,
+      trailing: false,
     })
 
     debouncedFn('first')


### PR DESCRIPTION
If the leading option is set to true, the function is executed twice: once for leading and once for trailing execution. Adding a trailing option allows the caller to define whether they want this to occur.