### PR TITLE
fix: incorrect package repository url

### DIFF
--- a/.changeset/wild-doodles-cough.md
+++ b/.changeset/wild-doodles-cough.md
@@ -1,0 +1,6 @@
+---
+'@tanstack/react-persister': patch
+'@tanstack/persister': patch
+---
+
+fix github url for publishing

--- a/packages/persister/package.json
+++ b/packages/persister/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/TanStack/persister.git",
+    "url": "https://github.com/TanStack/pacer.git",
     "directory": "packages/persister"
   },
   "homepage": "https://tanstack.com/persister",


### PR DESCRIPTION
The release pipeline was broken in the latest refactor to use @tanstack/store because the new persister package has the wrong repository url specified in its package.json

```bash
🦋  error an error occurred while publishing @tanstack/persister: E422 422 Unprocessable Entity - PUT https://registry.npmjs.org/@tanstack%2fpersister - Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "git+https://github.com/TanStack/persister.git", expected to match "https://github.com/TanStack/pacer" from provenance 
🦋  error npm notice Publishing to https://registry.npmjs.org/ with tag latest and public access
🦋  error npm notice publish Signed provenance statement with source and build information from GitHub Actions
🦋  error npm notice publish Provenance statement published to transparency log: https://search.sigstore.dev/?logIndex=271056349
🦋  error npm error code E422
🦋  error npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/@tanstack%2fpersister - Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "git+https://github.com/TanStack/persister.git", expected to match "https://github.com/TanStack/pacer" from provenance
```