### PR TITLE
fix(adapters): use latest onUnmount callback during cleanup

### DIFF
--- a/.changeset/fair-donuts-chew.md
+++ b/.changeset/fair-donuts-chew.md
@@ -1,0 +1,6 @@
+---
+'@tanstack/react-pacer': patch
+'@tanstack/preact-pacer': patch
+---
+
+Use the latest `onUnmount` callback during cleanup so adapter teardown reflects current options instead of the initial render.

--- a/packages/preact-pacer/src/debouncer/useDebouncer.ts
+++ b/packages/preact-pacer/src/debouncer/useDebouncer.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'preact/hooks'
+import { useEffect, useMemo, useRef, useState } from 'preact/hooks'
 import { Debouncer } from '@tanstack/pacer/debouncer'
 import { shallow, useStore } from '@tanstack/preact-store'
 import { useDefaultPacerOptions } from '../provider/PacerProvider'
@@ -193,6 +193,8 @@ export function useDebouncer<TFn extends AnyFunction, TSelected = {}>(
 
   debouncer.fn = fn
   debouncer.setOptions(mergedOptions)
+  const onUnmountRef = useRef(mergedOptions.onUnmount)
+  onUnmountRef.current = mergedOptions.onUnmount
 
   /* eslint-disable react-hooks/exhaustive-deps -- cleanup only; runs on unmount */
   useEffect(() => {

--- a/packages/preact-pacer/src/debouncer/useDebouncer.ts
+++ b/packages/preact-pacer/src/debouncer/useDebouncer.ts
@@ -199,8 +199,8 @@ export function useDebouncer<TFn extends AnyFunction, TSelected = {}>(
   /* eslint-disable react-hooks/exhaustive-deps -- cleanup only; runs on unmount */
   useEffect(() => {
     return () => {
-      if (mergedOptions.onUnmount) {
-        mergedOptions.onUnmount(debouncer)
+      if (onUnmountRef.current) {
+        onUnmountRef.current(debouncer)
       } else {
         debouncer.cancel()
       }

--- a/packages/react-pacer/src/async-debouncer/useAsyncDebouncer.ts
+++ b/packages/react-pacer/src/async-debouncer/useAsyncDebouncer.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { AsyncDebouncer } from '@tanstack/pacer/async-debouncer'
 import { shallow, useStore } from '@tanstack/react-store'
 import { useDefaultPacerOptions } from '../provider/PacerProvider'
@@ -248,14 +248,16 @@ export function useAsyncDebouncer<TFn extends AnyAsyncFunction, TSelected = {}>(
 
   asyncDebouncer.fn = fn
   asyncDebouncer.setOptions(mergedOptions)
+  const onUnmountRef = useRef(mergedOptions.onUnmount)
+  onUnmountRef.current = mergedOptions.onUnmount
 
   const state = useStore(asyncDebouncer.store, selector, shallow)
 
   /* eslint-disable react-hooks/exhaustive-deps, @eslint-react/exhaustive-deps, react-compiler/react-compiler -- unmount cleanup only; empty deps keep teardown stable */
   useEffect(() => {
     return () => {
-      if (mergedOptions.onUnmount) {
-        mergedOptions.onUnmount(asyncDebouncer)
+      if (onUnmountRef.current) {
+        onUnmountRef.current(asyncDebouncer)
       } else {
         asyncDebouncer.cancel()
         asyncDebouncer.abort()

--- a/packages/react-pacer/src/debouncer/useDebouncer.ts
+++ b/packages/react-pacer/src/debouncer/useDebouncer.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { Debouncer } from '@tanstack/pacer/debouncer'
 import { shallow, useStore } from '@tanstack/react-store'
 import { useDefaultPacerOptions } from '../provider/PacerProvider'
@@ -196,12 +196,14 @@ export function useDebouncer<TFn extends AnyFunction, TSelected = {}>(
 
   debouncer.fn = fn
   debouncer.setOptions(mergedOptions)
+  const onUnmountRef = useRef(mergedOptions.onUnmount)
+  onUnmountRef.current = mergedOptions.onUnmount
 
   /* eslint-disable react-hooks/exhaustive-deps, @eslint-react/exhaustive-deps, react-compiler/react-compiler -- unmount cleanup only; empty deps keep teardown stable */
   useEffect(() => {
     return () => {
-      if (mergedOptions.onUnmount) {
-        mergedOptions.onUnmount(debouncer)
+      if (onUnmountRef.current) {
+        onUnmountRef.current(debouncer)
       } else {
         debouncer.cancel()
       }

--- a/packages/react-pacer/src/rate-limiter/useRateLimiter.ts
+++ b/packages/react-pacer/src/rate-limiter/useRateLimiter.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { RateLimiter } from '@tanstack/pacer/rate-limiter'
 import { shallow, useStore } from '@tanstack/react-store'
 import { useDefaultPacerOptions } from '../provider/PacerProvider'
@@ -223,12 +223,14 @@ export function useRateLimiter<TFn extends AnyFunction, TSelected = {}>(
 
   rateLimiter.fn = fn
   rateLimiter.setOptions(mergedOptions)
+  const onUnmountRef = useRef(mergedOptions.onUnmount)
+  onUnmountRef.current = mergedOptions.onUnmount
 
   /* eslint-disable react-hooks/exhaustive-deps, @eslint-react/exhaustive-deps, react-compiler/react-compiler -- unmount cleanup only; empty deps keep teardown stable */
   useEffect(() => {
     return () => {
-      if (mergedOptions.onUnmount) {
-        mergedOptions.onUnmount(rateLimiter)
+      if (onUnmountRef.current) {
+        onUnmountRef.current(rateLimiter)
       }
     }
   }, [])


### PR DESCRIPTION
## 🎯 Changes

This PR fixes a stale cleanup callback issue in the adapter hooks that support `onUnmount`.

Before this change, these hooks registered an unmount cleanup with an empty dependency array and read `mergedOptions.onUnmount` directly inside that cleanup. That meant the cleanup closed over the value from the first render. If a consumer re-rendered with a new `onUnmount` callback, the hook could still call the old callback during unmount.

This change keeps the existing "register cleanup once" behavior, but makes the cleanup read the latest `onUnmount` callback instead of the initial one.

Updated hooks:
- `packages/react-pacer/src/debouncer/useDebouncer.ts`
- `packages/react-pacer/src/async-debouncer/useAsyncDebouncer.ts`
- `packages/react-pacer/src/rate-limiter/useRateLimiter.ts`
- `packages/preact-pacer/src/debouncer/useDebouncer.ts`

### Why this approach

I wanted to keep this fix as small and low-risk as possible.

I considered whether the previous behavior might have been intentional, since the cleanup effect is deliberately registered with `[]` to keep teardown stable. However, the rest of these hooks already update runtime behavior from the latest render by reassigning `fn` and calling `setOptions(mergedOptions)` on each render. Given that, treating `onUnmount` as "initial render only" felt inconsistent with the rest of the hook contract and with how consumers would naturally expect a cleanup option to behave.

Because of that, I treated this as a stale-closure bug rather than an intentional "initial-only" API.

### What changed in the implementation

The change is intentionally minimal:
- keep the existing empty-deps cleanup effect
- keep the existing default cleanup behavior
- avoid introducing a new custom hook such as `useLatest`
- avoid changing the public API
- store only the latest `onUnmount` callback in a ref
- read `ref.current` inside the unmount cleanup

So the behavior changes only in one place:
- previously: cleanup used the first-render `onUnmount`
- now: cleanup uses the latest `onUnmount`

### Motivation

This matters when `onUnmount` depends on props or render-time values and changes over the component lifecycle. In that case, the old behavior could execute outdated cleanup logic during unmount.

This PR fixes that without changing how often the effect is registered or how the default teardown works.

### Local validation

I did not run the full `pnpm run test:pr` suite.

I validated the change with targeted checks:
- `pnpm --filter @tanstack/pacer exec vitest run tests/async-debouncer.test.ts tests/async-throttler.test.ts tests/async-rate-limiter.test.ts`
- `pnpm --filter @tanstack/pacer build`
- `pnpm --filter @tanstack/react-pacer test:types`
- `pnpm --filter @tanstack/preact-pacer test:types`

## ✅ Checklist

- [ ] I have followed the steps in the [Contributing guide](https://github.com/TanStack/pacer/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure the latest unmount callbacks are invoked for debouncing and rate-limiting hooks on component teardown, preventing stale callbacks and improving cancellation/abort consistency across re-renders. No public APIs changed.
* **Chores**
  * Added release metadata to publish these fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->