### PR TITLE
fix(async-queuer): use nullish check in #tick to handle falsy queue items

### DIFF
--- a/.changeset/young-planes-clap.md
+++ b/.changeset/young-planes-clap.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/pacer': patch
+---
+
+fix(async-queuer): Fix falsy item handling in AsyncQueuer#tick — items like 0, "", and false are no longer silently dropped from the processing loop.

--- a/packages/pacer/src/async-queuer.ts
+++ b/packages/pacer/src/async-queuer.ts
@@ -437,7 +437,7 @@ export class AsyncQueuer<TValue> {
       this.store.state.items.length > 0
     ) {
       const nextItem = this.peekNextItem()
-      if (!nextItem) {
+      if (nextItem === undefined) {
         break
       }
       activeItems.push(nextItem)

--- a/packages/pacer/tests/async-queuer.test.ts
+++ b/packages/pacer/tests/async-queuer.test.ts
@@ -1095,4 +1095,70 @@ describe('AsyncQueuer', () => {
       expect(asyncQueuer.getAbortSignal()).toBeNull()
     })
   })
+
+  describe('falsy item handling', () => {
+    it('should process items with value 0', async () => {
+      const processed: Array<number> = []
+      const asyncQueuer = new AsyncQueuer<number>(
+        async (item) => {
+          processed.push(item)
+          return item
+        },
+        { started: false },
+      )
+
+      asyncQueuer.addItem(0)
+      asyncQueuer.addItem(1)
+      asyncQueuer.addItem(2)
+      asyncQueuer.start()
+
+      await vi.advanceTimersByTimeAsync(100)
+
+      expect(processed).toEqual([0, 1, 2])
+      expect(asyncQueuer.store.state.successCount).toBe(3)
+    })
+
+    it('should process items with value "" (empty string)', async () => {
+      const processed: Array<string> = []
+      const asyncQueuer = new AsyncQueuer<string>(
+        async (item) => {
+          processed.push(item)
+          return item
+        },
+        { started: false },
+      )
+
+      asyncQueuer.addItem('')
+      asyncQueuer.addItem('hello')
+      asyncQueuer.addItem('')
+      asyncQueuer.start()
+
+      await vi.advanceTimersByTimeAsync(100)
+
+      expect(processed).toEqual(['', 'hello', ''])
+      expect(asyncQueuer.store.state.successCount).toBe(3)
+    })
+
+    it('should process items with value false', async () => {
+      const processed: Array<boolean> = []
+      const asyncQueuer = new AsyncQueuer<boolean>(
+        async (item) => {
+          processed.push(item)
+          return item
+        },
+        { started: false },
+      )
+
+      asyncQueuer.addItem(false)
+      asyncQueuer.addItem(true)
+      asyncQueuer.addItem(false)
+      asyncQueuer.start()
+
+      await vi.advanceTimersByTimeAsync(100)
+
+      expect(processed).toEqual([false, true, false])
+      expect(asyncQueuer.store.state.successCount).toBe(3)
+    })
+
+  })
 })


### PR DESCRIPTION
## 🎯 Changes

Fixes https://github.com/TanStack/pacer/issues/200

`AsyncQueuer#tick()` used `if (!nextItem)` to check whether the queue was empty, which caused falsy items (`0`, `""`, `false`) to be silently skipped. Changed to `if (nextItem === undefined)` to match the sentinel already used by `getNextItem()` and `execute()`.

Added tests verifying that items with values `0`, `""`, and `false` are processed correctly.

The issue is actually deeper than this, but this PR aim to make the minimal fix for this cases. A better fix would be to refactor some methods signature from `TValue | undefined` to something like `{ hasItem: false } | { hasItem: true, item: TValue }` in order to also allow `undefined` as a value (as nothing in `addItem` or `TValue` prevent having an undefined item), but it would require a major version change.

Note: I didn't add a test for `null`, because this value makes other part of the code crash (priority computing) which should be fixed in other issues/PRs.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/pacer/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue where queued items with falsy values (`0`, empty string, `false`) were incorrectly excluded from processing, ensuring they are now properly handled and processed as intended.

## Tests
* Added test coverage for falsy item handling to verify correct processing of items with falsy values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->