### PR TITLE
fix(overrides): move overrides to pnpm workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,17 +74,5 @@
     "tsdown": "^0.22.0",
     "typescript": "6.0.3",
     "vitest": "^4.1.5"
-  },
-  "overrides": {
-    "@tanstack/angular-pacer": "workspace:*",
-    "@tanstack/pacer": "workspace:*",
-    "@tanstack/pacer-devtools": "workspace:*",
-    "@tanstack/pacer-lite": "workspace:*",
-    "@tanstack/preact-pacer": "workspace:*",
-    "@tanstack/preact-pacer-devtools": "workspace:*",
-    "@tanstack/react-pacer": "workspace:*",
-    "@tanstack/react-pacer-devtools": "workspace:*",
-    "@tanstack/solid-pacer": "workspace:*",
-    "@tanstack/solid-pacer-devtools": "workspace:*"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,18 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@tanstack/angular-pacer': workspace:*
+  '@tanstack/pacer': workspace:*
+  '@tanstack/pacer-devtools': workspace:*
+  '@tanstack/pacer-lite': workspace:*
+  '@tanstack/preact-pacer': workspace:*
+  '@tanstack/preact-pacer-devtools': workspace:*
+  '@tanstack/react-pacer': workspace:*
+  '@tanstack/react-pacer-devtools': workspace:*
+  '@tanstack/solid-pacer': workspace:*
+  '@tanstack/solid-pacer-devtools': workspace:*
+
 importers:
 
   .:
@@ -73,7 +85,7 @@ importers:
         version: 0.2.16
       tsdown:
         specifier: ^0.22.0
-        version: 0.22.0(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(publint@0.3.20)(typescript@6.0.3)(unrun@0.2.37)
+        version: 0.22.0(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(publint@0.3.20)(typescript@6.0.3)
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -102,7 +114,7 @@ importers:
         specifier: ^21.2.12
         version: 21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(@angular/platform-browser@21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2)))(rxjs@7.8.2)
       '@tanstack/angular-pacer':
-        specifier: ^0.23.0
+        specifier: workspace:*
         version: link:../../../packages/angular-pacer
       rxjs:
         specifier: ~7.8.2
@@ -151,7 +163,7 @@ importers:
         specifier: ^21.2.12
         version: 21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(@angular/platform-browser@21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2)))(rxjs@7.8.2)
       '@tanstack/angular-pacer':
-        specifier: ^0.23.0
+        specifier: workspace:*
         version: link:../../../packages/angular-pacer
       rxjs:
         specifier: ~7.8.2
@@ -200,7 +212,7 @@ importers:
         specifier: ^21.2.12
         version: 21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(@angular/platform-browser@21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2)))(rxjs@7.8.2)
       '@tanstack/angular-pacer':
-        specifier: ^0.23.0
+        specifier: workspace:*
         version: link:../../../packages/angular-pacer
       rxjs:
         specifier: ~7.8.2
@@ -249,7 +261,7 @@ importers:
         specifier: ^21.2.12
         version: 21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(@angular/platform-browser@21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2)))(rxjs@7.8.2)
       '@tanstack/angular-pacer':
-        specifier: ^0.23.0
+        specifier: workspace:*
         version: link:../../../packages/angular-pacer
       rxjs:
         specifier: ~7.8.2
@@ -298,7 +310,7 @@ importers:
         specifier: ^21.2.12
         version: 21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(@angular/platform-browser@21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2)))(rxjs@7.8.2)
       '@tanstack/angular-pacer':
-        specifier: ^0.23.0
+        specifier: workspace:*
         version: link:../../../packages/angular-pacer
       rxjs:
         specifier: ~7.8.2
@@ -347,7 +359,7 @@ importers:
         specifier: ^21.2.12
         version: 21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(@angular/platform-browser@21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2)))(rxjs@7.8.2)
       '@tanstack/angular-pacer':
-        specifier: ^0.23.0
+        specifier: workspace:*
         version: link:../../../packages/angular-pacer
       rxjs:
         specifier: ~7.8.2
@@ -396,7 +408,7 @@ importers:
         specifier: ^21.2.12
         version: 21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(@angular/platform-browser@21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2)))(rxjs@7.8.2)
       '@tanstack/angular-pacer':
-        specifier: ^0.23.0
+        specifier: workspace:*
         version: link:../../../packages/angular-pacer
       rxjs:
         specifier: ~7.8.2
@@ -445,7 +457,7 @@ importers:
         specifier: ^21.2.12
         version: 21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(@angular/platform-browser@21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2)))(rxjs@7.8.2)
       '@tanstack/angular-pacer':
-        specifier: ^0.23.0
+        specifier: workspace:*
         version: link:../../../packages/angular-pacer
       rxjs:
         specifier: ~7.8.2
@@ -494,7 +506,7 @@ importers:
         specifier: ^21.2.12
         version: 21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(@angular/platform-browser@21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2)))(rxjs@7.8.2)
       '@tanstack/angular-pacer':
-        specifier: ^0.23.0
+        specifier: workspace:*
         version: link:../../../packages/angular-pacer
       rxjs:
         specifier: ~7.8.2
@@ -543,7 +555,7 @@ importers:
         specifier: ^21.2.12
         version: 21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(@angular/platform-browser@21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2)))(rxjs@7.8.2)
       '@tanstack/angular-pacer':
-        specifier: ^0.23.0
+        specifier: workspace:*
         version: link:../../../packages/angular-pacer
       rxjs:
         specifier: ~7.8.2
@@ -592,7 +604,7 @@ importers:
         specifier: ^21.2.12
         version: 21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(@angular/platform-browser@21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2)))(rxjs@7.8.2)
       '@tanstack/angular-pacer':
-        specifier: ^0.23.0
+        specifier: workspace:*
         version: link:../../../packages/angular-pacer
       rxjs:
         specifier: ~7.8.2
@@ -641,7 +653,7 @@ importers:
         specifier: ^21.2.12
         version: 21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(@angular/platform-browser@21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2)))(rxjs@7.8.2)
       '@tanstack/angular-pacer':
-        specifier: ^0.23.0
+        specifier: workspace:*
         version: link:../../../packages/angular-pacer
       rxjs:
         specifier: ~7.8.2
@@ -690,7 +702,7 @@ importers:
         specifier: ^21.2.12
         version: 21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(@angular/platform-browser@21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2)))(rxjs@7.8.2)
       '@tanstack/angular-pacer':
-        specifier: ^0.23.0
+        specifier: workspace:*
         version: link:../../../packages/angular-pacer
       rxjs:
         specifier: ~7.8.2
@@ -739,7 +751,7 @@ importers:
         specifier: ^21.2.12
         version: 21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(@angular/platform-browser@21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2)))(rxjs@7.8.2)
       '@tanstack/angular-pacer':
-        specifier: ^0.23.0
+        specifier: workspace:*
         version: link:../../../packages/angular-pacer
       rxjs:
         specifier: ~7.8.2
@@ -788,7 +800,7 @@ importers:
         specifier: ^21.2.12
         version: 21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(@angular/platform-browser@21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2)))(rxjs@7.8.2)
       '@tanstack/angular-pacer':
-        specifier: ^0.23.0
+        specifier: workspace:*
         version: link:../../../packages/angular-pacer
       rxjs:
         specifier: ~7.8.2
@@ -837,7 +849,7 @@ importers:
         specifier: ^21.2.12
         version: 21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(@angular/platform-browser@21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2)))(rxjs@7.8.2)
       '@tanstack/angular-pacer':
-        specifier: ^0.23.0
+        specifier: workspace:*
         version: link:../../../packages/angular-pacer
       rxjs:
         specifier: ~7.8.2
@@ -886,7 +898,7 @@ importers:
         specifier: ^21.2.12
         version: 21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(@angular/platform-browser@21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2)))(rxjs@7.8.2)
       '@tanstack/angular-pacer':
-        specifier: ^0.23.0
+        specifier: workspace:*
         version: link:../../../packages/angular-pacer
       rxjs:
         specifier: ~7.8.2
@@ -935,7 +947,7 @@ importers:
         specifier: ^21.2.12
         version: 21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(@angular/platform-browser@21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2)))(rxjs@7.8.2)
       '@tanstack/angular-pacer':
-        specifier: ^0.23.0
+        specifier: workspace:*
         version: link:../../../packages/angular-pacer
       rxjs:
         specifier: ~7.8.2
@@ -984,7 +996,7 @@ importers:
         specifier: ^21.2.12
         version: 21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(@angular/platform-browser@21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2)))(rxjs@7.8.2)
       '@tanstack/angular-pacer':
-        specifier: ^0.23.0
+        specifier: workspace:*
         version: link:../../../packages/angular-pacer
       rxjs:
         specifier: ~7.8.2
@@ -1033,7 +1045,7 @@ importers:
         specifier: ^21.2.12
         version: 21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(@angular/platform-browser@21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2)))(rxjs@7.8.2)
       '@tanstack/angular-pacer':
-        specifier: ^0.23.0
+        specifier: workspace:*
         version: link:../../../packages/angular-pacer
       rxjs:
         specifier: ~7.8.2
@@ -1082,7 +1094,7 @@ importers:
         specifier: ^21.2.12
         version: 21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(@angular/platform-browser@21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2)))(rxjs@7.8.2)
       '@tanstack/angular-pacer':
-        specifier: ^0.23.0
+        specifier: workspace:*
         version: link:../../../packages/angular-pacer
       rxjs:
         specifier: ~7.8.2
@@ -1131,7 +1143,7 @@ importers:
         specifier: ^21.2.12
         version: 21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(@angular/platform-browser@21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2)))(rxjs@7.8.2)
       '@tanstack/angular-pacer':
-        specifier: ^0.23.0
+        specifier: workspace:*
         version: link:../../../packages/angular-pacer
       rxjs:
         specifier: ~7.8.2
@@ -1180,7 +1192,7 @@ importers:
         specifier: ^21.2.12
         version: 21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(@angular/platform-browser@21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2)))(rxjs@7.8.2)
       '@tanstack/angular-pacer':
-        specifier: ^0.23.0
+        specifier: workspace:*
         version: link:../../../packages/angular-pacer
       rxjs:
         specifier: ~7.8.2
@@ -1229,7 +1241,7 @@ importers:
         specifier: ^21.2.12
         version: 21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(@angular/platform-browser@21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2)))(rxjs@7.8.2)
       '@tanstack/angular-pacer':
-        specifier: ^0.23.0
+        specifier: workspace:*
         version: link:../../../packages/angular-pacer
       rxjs:
         specifier: ~7.8.2
@@ -1278,7 +1290,7 @@ importers:
         specifier: ^21.2.12
         version: 21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(@angular/platform-browser@21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2)))(rxjs@7.8.2)
       '@tanstack/angular-pacer':
-        specifier: ^0.23.0
+        specifier: workspace:*
         version: link:../../../packages/angular-pacer
       rxjs:
         specifier: ~7.8.2
@@ -1327,7 +1339,7 @@ importers:
         specifier: ^21.2.12
         version: 21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(@angular/platform-browser@21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2)))(rxjs@7.8.2)
       '@tanstack/angular-pacer':
-        specifier: ^0.23.0
+        specifier: workspace:*
         version: link:../../../packages/angular-pacer
       rxjs:
         specifier: ~7.8.2
@@ -1376,7 +1388,7 @@ importers:
         specifier: ^21.2.12
         version: 21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(@angular/platform-browser@21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2)))(rxjs@7.8.2)
       '@tanstack/angular-pacer':
-        specifier: ^0.23.0
+        specifier: workspace:*
         version: link:../../../packages/angular-pacer
       rxjs:
         specifier: ~7.8.2
@@ -1425,7 +1437,7 @@ importers:
         specifier: ^21.2.12
         version: 21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(@angular/platform-browser@21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2)))(rxjs@7.8.2)
       '@tanstack/angular-pacer':
-        specifier: ^0.23.0
+        specifier: workspace:*
         version: link:../../../packages/angular-pacer
       rxjs:
         specifier: ~7.8.2
@@ -1474,7 +1486,7 @@ importers:
         specifier: ^21.2.12
         version: 21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(@angular/platform-browser@21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2)))(rxjs@7.8.2)
       '@tanstack/angular-pacer':
-        specifier: ^0.23.0
+        specifier: workspace:*
         version: link:../../../packages/angular-pacer
       rxjs:
         specifier: ~7.8.2
@@ -1523,7 +1535,7 @@ importers:
         specifier: ^21.2.12
         version: 21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(@angular/platform-browser@21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2)))(rxjs@7.8.2)
       '@tanstack/angular-pacer':
-        specifier: ^0.23.0
+        specifier: workspace:*
         version: link:../../../packages/angular-pacer
       rxjs:
         specifier: ~7.8.2
@@ -1572,7 +1584,7 @@ importers:
         specifier: ^21.2.12
         version: 21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(@angular/platform-browser@21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2)))(rxjs@7.8.2)
       '@tanstack/angular-pacer':
-        specifier: ^0.23.0
+        specifier: workspace:*
         version: link:../../../packages/angular-pacer
       rxjs:
         specifier: ~7.8.2
@@ -1621,7 +1633,7 @@ importers:
         specifier: ^21.2.12
         version: 21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(@angular/platform-browser@21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2)))(rxjs@7.8.2)
       '@tanstack/angular-pacer':
-        specifier: ^0.23.0
+        specifier: workspace:*
         version: link:../../../packages/angular-pacer
       rxjs:
         specifier: ~7.8.2
@@ -1670,7 +1682,7 @@ importers:
         specifier: ^21.2.12
         version: 21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(@angular/platform-browser@21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2)))(rxjs@7.8.2)
       '@tanstack/angular-pacer':
-        specifier: ^0.23.0
+        specifier: workspace:*
         version: link:../../../packages/angular-pacer
       rxjs:
         specifier: ~7.8.2
@@ -1719,7 +1731,7 @@ importers:
         specifier: ^21.2.12
         version: 21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(@angular/platform-browser@21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2)))(rxjs@7.8.2)
       '@tanstack/angular-pacer':
-        specifier: ^0.23.0
+        specifier: workspace:*
         version: link:../../../packages/angular-pacer
       rxjs:
         specifier: ~7.8.2
@@ -1768,7 +1780,7 @@ importers:
         specifier: ^21.2.12
         version: 21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(@angular/platform-browser@21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2)))(rxjs@7.8.2)
       '@tanstack/angular-pacer':
-        specifier: ^0.23.0
+        specifier: workspace:*
         version: link:../../../packages/angular-pacer
       rxjs:
         specifier: ~7.8.2
@@ -1817,7 +1829,7 @@ importers:
         specifier: ^21.2.12
         version: 21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(@angular/platform-browser@21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2)))(rxjs@7.8.2)
       '@tanstack/angular-pacer':
-        specifier: ^0.23.0
+        specifier: workspace:*
         version: link:../../../packages/angular-pacer
       rxjs:
         specifier: ~7.8.2
@@ -1866,7 +1878,7 @@ importers:
         specifier: ^21.2.12
         version: 21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(@angular/platform-browser@21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2)))(rxjs@7.8.2)
       '@tanstack/angular-pacer':
-        specifier: ^0.23.0
+        specifier: workspace:*
         version: link:../../../packages/angular-pacer
       rxjs:
         specifier: ~7.8.2
@@ -1915,7 +1927,7 @@ importers:
         specifier: ^21.2.12
         version: 21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(@angular/platform-browser@21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2)))(rxjs@7.8.2)
       '@tanstack/angular-pacer':
-        specifier: ^0.23.0
+        specifier: workspace:*
         version: link:../../../packages/angular-pacer
       rxjs:
         specifier: ~7.8.2
@@ -1964,7 +1976,7 @@ importers:
         specifier: ^21.2.12
         version: 21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(@angular/platform-browser@21.2.12(@angular/common@21.2.12(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.12(@angular/compiler@21.2.12)(rxjs@7.8.2)))(rxjs@7.8.2)
       '@tanstack/angular-pacer':
-        specifier: ^0.23.0
+        specifier: workspace:*
         version: link:../../../packages/angular-pacer
       rxjs:
         specifier: ~7.8.2
@@ -1995,7 +2007,7 @@ importers:
   examples/preact/asyncBatch:
     dependencies:
       '@tanstack/preact-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/preact-pacer
       preact:
         specifier: ^10.29.1
@@ -2011,7 +2023,7 @@ importers:
   examples/preact/asyncDebounce:
     dependencies:
       '@tanstack/preact-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/preact-pacer
       preact:
         specifier: ^10.29.1
@@ -2027,7 +2039,7 @@ importers:
   examples/preact/asyncRateLimit:
     dependencies:
       '@tanstack/preact-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/preact-pacer
       preact:
         specifier: ^10.29.1
@@ -2043,7 +2055,7 @@ importers:
   examples/preact/asyncRetry:
     dependencies:
       '@tanstack/preact-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/preact-pacer
       preact:
         specifier: ^10.29.1
@@ -2059,7 +2071,7 @@ importers:
   examples/preact/asyncThrottle:
     dependencies:
       '@tanstack/preact-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/preact-pacer
       preact:
         specifier: ^10.29.1
@@ -2075,7 +2087,7 @@ importers:
   examples/preact/batch:
     dependencies:
       '@tanstack/preact-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/preact-pacer
       preact:
         specifier: ^10.29.1
@@ -2091,7 +2103,7 @@ importers:
   examples/preact/debounce:
     dependencies:
       '@tanstack/preact-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/preact-pacer
       preact:
         specifier: ^10.29.1
@@ -2107,7 +2119,7 @@ importers:
   examples/preact/queue:
     dependencies:
       '@tanstack/preact-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/preact-pacer
       preact:
         specifier: ^10.29.1
@@ -2123,7 +2135,7 @@ importers:
   examples/preact/rateLimit:
     dependencies:
       '@tanstack/preact-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/preact-pacer
       preact:
         specifier: ^10.29.1
@@ -2139,7 +2151,7 @@ importers:
   examples/preact/throttle:
     dependencies:
       '@tanstack/preact-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/preact-pacer
       preact:
         specifier: ^10.29.1
@@ -2155,7 +2167,7 @@ importers:
   examples/preact/useAsyncBatchedCallback:
     dependencies:
       '@tanstack/preact-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/preact-pacer
       preact:
         specifier: ^10.29.1
@@ -2171,7 +2183,7 @@ importers:
   examples/preact/useAsyncBatcher:
     dependencies:
       '@tanstack/preact-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/preact-pacer
       preact:
         specifier: ^10.29.1
@@ -2187,7 +2199,7 @@ importers:
   examples/preact/useAsyncDebouncedCallback:
     dependencies:
       '@tanstack/preact-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/preact-pacer
       preact:
         specifier: ^10.29.1
@@ -2203,7 +2215,7 @@ importers:
   examples/preact/useAsyncDebouncer:
     dependencies:
       '@tanstack/preact-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/preact-pacer
       preact:
         specifier: ^10.29.1
@@ -2219,7 +2231,7 @@ importers:
   examples/preact/useAsyncQueuedState:
     dependencies:
       '@tanstack/preact-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/preact-pacer
       preact:
         specifier: ^10.29.1
@@ -2235,7 +2247,7 @@ importers:
   examples/preact/useAsyncQueuer:
     dependencies:
       '@tanstack/preact-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/preact-pacer
       preact:
         specifier: ^10.29.1
@@ -2251,7 +2263,7 @@ importers:
   examples/preact/useAsyncRateLimiter:
     dependencies:
       '@tanstack/preact-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/preact-pacer
       preact:
         specifier: ^10.29.1
@@ -2267,7 +2279,7 @@ importers:
   examples/preact/useAsyncRateLimiterWithPersister:
     dependencies:
       '@tanstack/preact-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/preact-pacer
       preact:
         specifier: ^10.29.1
@@ -2283,7 +2295,7 @@ importers:
   examples/preact/useAsyncThrottledCallback:
     dependencies:
       '@tanstack/preact-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/preact-pacer
       preact:
         specifier: ^10.29.1
@@ -2299,7 +2311,7 @@ importers:
   examples/preact/useAsyncThrottler:
     dependencies:
       '@tanstack/preact-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/preact-pacer
       preact:
         specifier: ^10.29.1
@@ -2315,7 +2327,7 @@ importers:
   examples/preact/useBatchedCallback:
     dependencies:
       '@tanstack/preact-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/preact-pacer
       preact:
         specifier: ^10.29.1
@@ -2331,7 +2343,7 @@ importers:
   examples/preact/useBatcher:
     dependencies:
       '@tanstack/preact-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/preact-pacer
       preact:
         specifier: ^10.29.1
@@ -2347,7 +2359,7 @@ importers:
   examples/preact/useDebouncedCallback:
     dependencies:
       '@tanstack/preact-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/preact-pacer
       preact:
         specifier: ^10.29.1
@@ -2363,7 +2375,7 @@ importers:
   examples/preact/useDebouncedState:
     dependencies:
       '@tanstack/preact-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/preact-pacer
       preact:
         specifier: ^10.29.1
@@ -2379,7 +2391,7 @@ importers:
   examples/preact/useDebouncedValue:
     dependencies:
       '@tanstack/preact-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/preact-pacer
       preact:
         specifier: ^10.29.1
@@ -2395,7 +2407,7 @@ importers:
   examples/preact/useDebouncer:
     dependencies:
       '@tanstack/preact-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/preact-pacer
       preact:
         specifier: ^10.29.1
@@ -2411,7 +2423,7 @@ importers:
   examples/preact/useQueuedState:
     dependencies:
       '@tanstack/preact-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/preact-pacer
       preact:
         specifier: ^10.29.1
@@ -2427,7 +2439,7 @@ importers:
   examples/preact/useQueuedValue:
     dependencies:
       '@tanstack/preact-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/preact-pacer
       preact:
         specifier: ^10.29.1
@@ -2446,7 +2458,7 @@ importers:
         specifier: ^0.10.2
         version: 0.10.2(csstype@3.2.3)(preact@10.29.1)(solid-js@1.9.12)
       '@tanstack/preact-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/preact-pacer
       '@tanstack/preact-pacer-devtools':
         specifier: workspace:*
@@ -2465,7 +2477,7 @@ importers:
   examples/preact/useQueuerWithPersister:
     dependencies:
       '@tanstack/preact-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/preact-pacer
       preact:
         specifier: ^10.29.1
@@ -2481,7 +2493,7 @@ importers:
   examples/preact/useRateLimitedCallback:
     dependencies:
       '@tanstack/preact-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/preact-pacer
       preact:
         specifier: ^10.29.1
@@ -2497,7 +2509,7 @@ importers:
   examples/preact/useRateLimitedState:
     dependencies:
       '@tanstack/preact-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/preact-pacer
       preact:
         specifier: ^10.29.1
@@ -2513,7 +2525,7 @@ importers:
   examples/preact/useRateLimitedValue:
     dependencies:
       '@tanstack/preact-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/preact-pacer
       preact:
         specifier: ^10.29.1
@@ -2529,7 +2541,7 @@ importers:
   examples/preact/useRateLimiter:
     dependencies:
       '@tanstack/preact-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/preact-pacer
       preact:
         specifier: ^10.29.1
@@ -2545,7 +2557,7 @@ importers:
   examples/preact/useRateLimiterWithPersister:
     dependencies:
       '@tanstack/preact-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/preact-pacer
       preact:
         specifier: ^10.29.1
@@ -2561,7 +2573,7 @@ importers:
   examples/preact/useThrottledCallback:
     dependencies:
       '@tanstack/preact-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/preact-pacer
       preact:
         specifier: ^10.29.1
@@ -2577,7 +2589,7 @@ importers:
   examples/preact/useThrottledState:
     dependencies:
       '@tanstack/preact-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/preact-pacer
       preact:
         specifier: ^10.29.1
@@ -2593,7 +2605,7 @@ importers:
   examples/preact/useThrottledValue:
     dependencies:
       '@tanstack/preact-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/preact-pacer
       preact:
         specifier: ^10.29.1
@@ -2609,7 +2621,7 @@ importers:
   examples/preact/useThrottler:
     dependencies:
       '@tanstack/preact-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/preact-pacer
       preact:
         specifier: ^10.29.1
@@ -2628,7 +2640,7 @@ importers:
         specifier: ^0.10.2
         version: 0.10.2(csstype@3.2.3)(preact@10.29.1)(solid-js@1.9.12)
       '@tanstack/preact-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/preact-pacer
       '@tanstack/preact-pacer-devtools':
         specifier: workspace:*
@@ -2647,7 +2659,7 @@ importers:
   examples/react/asyncBatch:
     dependencies:
       '@tanstack/react-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/react-pacer
       react:
         specifier: ^19.2.6
@@ -2672,7 +2684,7 @@ importers:
   examples/react/asyncDebounce:
     dependencies:
       '@tanstack/react-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/react-pacer
       react:
         specifier: ^19.2.6
@@ -2697,7 +2709,7 @@ importers:
   examples/react/asyncRateLimit:
     dependencies:
       '@tanstack/react-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/react-pacer
       react:
         specifier: ^19.2.6
@@ -2722,7 +2734,7 @@ importers:
   examples/react/asyncRetry:
     dependencies:
       '@tanstack/react-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/react-pacer
       react:
         specifier: ^19.2.6
@@ -2747,7 +2759,7 @@ importers:
   examples/react/asyncThrottle:
     dependencies:
       '@tanstack/react-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/react-pacer
       react:
         specifier: ^19.2.6
@@ -2772,7 +2784,7 @@ importers:
   examples/react/batch:
     dependencies:
       '@tanstack/react-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/react-pacer
       react:
         specifier: ^19.2.6
@@ -2797,7 +2809,7 @@ importers:
   examples/react/debounce:
     dependencies:
       '@tanstack/react-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/react-pacer
       react:
         specifier: ^19.2.6
@@ -2822,7 +2834,7 @@ importers:
   examples/react/queue:
     dependencies:
       '@tanstack/react-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/react-pacer
       react:
         specifier: ^19.2.6
@@ -2835,7 +2847,7 @@ importers:
         specifier: 0.10.2
         version: 0.10.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(csstype@3.2.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(solid-js@1.9.12)
       '@tanstack/react-pacer-devtools':
-        specifier: 0.7.0
+        specifier: workspace:*
         version: link:../../../packages/react-pacer-devtools
       '@types/react':
         specifier: ^19.2.14
@@ -2853,7 +2865,7 @@ importers:
   examples/react/rateLimit:
     dependencies:
       '@tanstack/react-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/react-pacer
       react:
         specifier: ^19.2.6
@@ -2878,7 +2890,7 @@ importers:
   examples/react/react-query-debounced-prefetch:
     dependencies:
       '@tanstack/react-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/react-pacer
       '@tanstack/react-query':
         specifier: ^5.100.9
@@ -2909,7 +2921,7 @@ importers:
   examples/react/react-query-queued-prefetch:
     dependencies:
       '@tanstack/react-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/react-pacer
       '@tanstack/react-query':
         specifier: ^5.100.9
@@ -2940,7 +2952,7 @@ importers:
   examples/react/react-query-throttled-prefetch:
     dependencies:
       '@tanstack/react-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/react-pacer
       '@tanstack/react-query':
         specifier: ^5.100.9
@@ -2971,7 +2983,7 @@ importers:
   examples/react/throttle:
     dependencies:
       '@tanstack/react-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/react-pacer
       react:
         specifier: ^19.2.6
@@ -2996,7 +3008,7 @@ importers:
   examples/react/useAsyncBatchedCallback:
     dependencies:
       '@tanstack/react-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/react-pacer
       react:
         specifier: ^19.2.6
@@ -3021,7 +3033,7 @@ importers:
   examples/react/useAsyncBatcher:
     dependencies:
       '@tanstack/react-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/react-pacer
       react:
         specifier: ^19.2.6
@@ -3046,7 +3058,7 @@ importers:
   examples/react/useAsyncDebouncedCallback:
     dependencies:
       '@tanstack/react-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/react-pacer
       react:
         specifier: ^19.2.6
@@ -3071,7 +3083,7 @@ importers:
   examples/react/useAsyncDebouncer:
     dependencies:
       '@tanstack/react-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/react-pacer
       react:
         specifier: ^19.2.6
@@ -3096,7 +3108,7 @@ importers:
   examples/react/useAsyncQueuedState:
     dependencies:
       '@tanstack/react-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/react-pacer
       react:
         specifier: ^19.2.6
@@ -3121,7 +3133,7 @@ importers:
   examples/react/useAsyncQueuer:
     dependencies:
       '@tanstack/react-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/react-pacer
       react:
         specifier: ^19.2.6
@@ -3146,7 +3158,7 @@ importers:
   examples/react/useAsyncRateLimiter:
     dependencies:
       '@tanstack/react-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/react-pacer
       '@tanstack/react-persister':
         specifier: ^0.1.1
@@ -3174,7 +3186,7 @@ importers:
   examples/react/useAsyncRateLimiterWithPersister:
     dependencies:
       '@tanstack/react-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/react-pacer
       '@tanstack/react-persister':
         specifier: ^0.1.1
@@ -3202,7 +3214,7 @@ importers:
   examples/react/useAsyncThrottledCallback:
     dependencies:
       '@tanstack/react-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/react-pacer
       react:
         specifier: ^19.2.6
@@ -3227,7 +3239,7 @@ importers:
   examples/react/useAsyncThrottler:
     dependencies:
       '@tanstack/react-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/react-pacer
       react:
         specifier: ^19.2.6
@@ -3252,7 +3264,7 @@ importers:
   examples/react/useBatchedCallback:
     dependencies:
       '@tanstack/react-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/react-pacer
       react:
         specifier: ^19.2.6
@@ -3277,7 +3289,7 @@ importers:
   examples/react/useBatcher:
     dependencies:
       '@tanstack/react-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/react-pacer
       react:
         specifier: ^19.2.6
@@ -3302,7 +3314,7 @@ importers:
   examples/react/useDebouncedCallback:
     dependencies:
       '@tanstack/react-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/react-pacer
       react:
         specifier: ^19.2.6
@@ -3327,7 +3339,7 @@ importers:
   examples/react/useDebouncedState:
     dependencies:
       '@tanstack/react-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/react-pacer
       react:
         specifier: ^19.2.6
@@ -3352,7 +3364,7 @@ importers:
   examples/react/useDebouncedValue:
     dependencies:
       '@tanstack/react-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/react-pacer
       react:
         specifier: ^19.2.6
@@ -3377,7 +3389,7 @@ importers:
   examples/react/useDebouncer:
     dependencies:
       '@tanstack/react-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/react-pacer
       react:
         specifier: ^19.2.6
@@ -3402,7 +3414,7 @@ importers:
   examples/react/useQueuedState:
     dependencies:
       '@tanstack/react-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/react-pacer
       react:
         specifier: ^19.2.6
@@ -3427,7 +3439,7 @@ importers:
   examples/react/useQueuedValue:
     dependencies:
       '@tanstack/react-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/react-pacer
       react:
         specifier: ^19.2.6
@@ -3452,7 +3464,7 @@ importers:
   examples/react/useQueuer:
     dependencies:
       '@tanstack/react-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/react-pacer
       '@tanstack/react-persister':
         specifier: ^0.1.1
@@ -3468,7 +3480,7 @@ importers:
         specifier: 0.10.2
         version: 0.10.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(csstype@3.2.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(solid-js@1.9.12)
       '@tanstack/react-pacer-devtools':
-        specifier: 0.7.0
+        specifier: workspace:*
         version: link:../../../packages/react-pacer-devtools
       '@types/react':
         specifier: ^19.2.14
@@ -3486,7 +3498,7 @@ importers:
   examples/react/useQueuerWithPersister:
     dependencies:
       '@tanstack/react-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/react-pacer
       '@tanstack/react-persister':
         specifier: ^0.1.1
@@ -3514,7 +3526,7 @@ importers:
   examples/react/useRateLimitedCallback:
     dependencies:
       '@tanstack/react-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/react-pacer
       react:
         specifier: ^19.2.6
@@ -3539,7 +3551,7 @@ importers:
   examples/react/useRateLimitedState:
     dependencies:
       '@tanstack/react-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/react-pacer
       react:
         specifier: ^19.2.6
@@ -3564,7 +3576,7 @@ importers:
   examples/react/useRateLimitedValue:
     dependencies:
       '@tanstack/react-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/react-pacer
       react:
         specifier: ^19.2.6
@@ -3589,7 +3601,7 @@ importers:
   examples/react/useRateLimiter:
     dependencies:
       '@tanstack/react-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/react-pacer
       '@tanstack/react-persister':
         specifier: ^0.1.1
@@ -3617,7 +3629,7 @@ importers:
   examples/react/useRateLimiterWithPersister:
     dependencies:
       '@tanstack/react-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/react-pacer
       '@tanstack/react-persister':
         specifier: ^0.1.1
@@ -3645,7 +3657,7 @@ importers:
   examples/react/useThrottledCallback:
     dependencies:
       '@tanstack/react-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/react-pacer
       react:
         specifier: ^19.2.6
@@ -3670,7 +3682,7 @@ importers:
   examples/react/useThrottledState:
     dependencies:
       '@tanstack/react-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/react-pacer
       react:
         specifier: ^19.2.6
@@ -3695,7 +3707,7 @@ importers:
   examples/react/useThrottledValue:
     dependencies:
       '@tanstack/react-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/react-pacer
       react:
         specifier: ^19.2.6
@@ -3720,7 +3732,7 @@ importers:
   examples/react/useThrottler:
     dependencies:
       '@tanstack/react-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/react-pacer
       react:
         specifier: ^19.2.6
@@ -3745,7 +3757,7 @@ importers:
   examples/react/util-comparison:
     dependencies:
       '@tanstack/react-pacer':
-        specifier: ^0.22.0
+        specifier: workspace:*
         version: link:../../../packages/react-pacer
       react:
         specifier: ^19.2.6
@@ -3758,7 +3770,7 @@ importers:
         specifier: 0.10.2
         version: 0.10.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(csstype@3.2.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(solid-js@1.9.12)
       '@tanstack/react-pacer-devtools':
-        specifier: 0.7.0
+        specifier: workspace:*
         version: link:../../../packages/react-pacer-devtools
       '@types/react':
         specifier: ^19.2.14
@@ -3776,7 +3788,7 @@ importers:
   examples/solid/asyncBatch:
     dependencies:
       '@tanstack/solid-pacer':
-        specifier: ^0.21.0
+        specifier: workspace:*
         version: link:../../../packages/solid-pacer
       solid-js:
         specifier: ^1.9.12
@@ -3792,7 +3804,7 @@ importers:
   examples/solid/asyncDebounce:
     dependencies:
       '@tanstack/solid-pacer':
-        specifier: ^0.21.0
+        specifier: workspace:*
         version: link:../../../packages/solid-pacer
       solid-js:
         specifier: ^1.9.12
@@ -3808,7 +3820,7 @@ importers:
   examples/solid/asyncRateLimit:
     dependencies:
       '@tanstack/solid-pacer':
-        specifier: ^0.21.0
+        specifier: workspace:*
         version: link:../../../packages/solid-pacer
       solid-js:
         specifier: ^1.9.12
@@ -3824,7 +3836,7 @@ importers:
   examples/solid/asyncThrottle:
     dependencies:
       '@tanstack/solid-pacer':
-        specifier: ^0.21.0
+        specifier: workspace:*
         version: link:../../../packages/solid-pacer
       solid-js:
         specifier: ^1.9.12
@@ -3840,7 +3852,7 @@ importers:
   examples/solid/batch:
     dependencies:
       '@tanstack/solid-pacer':
-        specifier: ^0.21.0
+        specifier: workspace:*
         version: link:../../../packages/solid-pacer
       solid-js:
         specifier: ^1.9.12
@@ -3856,7 +3868,7 @@ importers:
   examples/solid/createAsyncBatcher:
     dependencies:
       '@tanstack/solid-pacer':
-        specifier: ^0.21.0
+        specifier: workspace:*
         version: link:../../../packages/solid-pacer
       solid-js:
         specifier: ^1.9.12
@@ -3872,7 +3884,7 @@ importers:
   examples/solid/createAsyncDebouncer:
     dependencies:
       '@tanstack/solid-pacer':
-        specifier: ^0.21.0
+        specifier: workspace:*
         version: link:../../../packages/solid-pacer
       solid-js:
         specifier: ^1.9.12
@@ -3888,7 +3900,7 @@ importers:
   examples/solid/createAsyncQueuer:
     dependencies:
       '@tanstack/solid-pacer':
-        specifier: ^0.21.0
+        specifier: workspace:*
         version: link:../../../packages/solid-pacer
       solid-js:
         specifier: ^1.9.12
@@ -3904,7 +3916,7 @@ importers:
   examples/solid/createAsyncRateLimiter:
     dependencies:
       '@tanstack/solid-pacer':
-        specifier: ^0.21.0
+        specifier: workspace:*
         version: link:../../../packages/solid-pacer
       solid-js:
         specifier: ^1.9.12
@@ -3920,7 +3932,7 @@ importers:
   examples/solid/createAsyncThrottler:
     dependencies:
       '@tanstack/solid-pacer':
-        specifier: ^0.21.0
+        specifier: workspace:*
         version: link:../../../packages/solid-pacer
       solid-js:
         specifier: ^1.9.12
@@ -3936,7 +3948,7 @@ importers:
   examples/solid/createBatcher:
     dependencies:
       '@tanstack/solid-pacer':
-        specifier: ^0.21.0
+        specifier: workspace:*
         version: link:../../../packages/solid-pacer
       solid-js:
         specifier: ^1.9.12
@@ -3952,7 +3964,7 @@ importers:
   examples/solid/createDebouncedSignal:
     dependencies:
       '@tanstack/solid-pacer':
-        specifier: ^0.21.0
+        specifier: workspace:*
         version: link:../../../packages/solid-pacer
       solid-js:
         specifier: ^1.9.12
@@ -3968,7 +3980,7 @@ importers:
   examples/solid/createDebouncedValue:
     dependencies:
       '@tanstack/solid-pacer':
-        specifier: ^0.21.0
+        specifier: workspace:*
         version: link:../../../packages/solid-pacer
       solid-js:
         specifier: ^1.9.12
@@ -3984,7 +3996,7 @@ importers:
   examples/solid/createDebouncer:
     dependencies:
       '@tanstack/solid-pacer':
-        specifier: ^0.21.0
+        specifier: workspace:*
         version: link:../../../packages/solid-pacer
       solid-js:
         specifier: ^1.9.12
@@ -4003,10 +4015,10 @@ importers:
         specifier: 0.8.2
         version: 0.8.2(csstype@3.2.3)(solid-js@1.9.12)
       '@tanstack/solid-pacer':
-        specifier: ^0.21.0
+        specifier: workspace:*
         version: link:../../../packages/solid-pacer
       '@tanstack/solid-pacer-devtools':
-        specifier: 0.6.2
+        specifier: workspace:*
         version: link:../../../packages/solid-pacer-devtools
       solid-js:
         specifier: ^1.9.12
@@ -4025,10 +4037,10 @@ importers:
         specifier: 0.8.2
         version: 0.8.2(csstype@3.2.3)(solid-js@1.9.12)
       '@tanstack/solid-pacer':
-        specifier: ^0.21.0
+        specifier: workspace:*
         version: link:../../../packages/solid-pacer
       '@tanstack/solid-pacer-devtools':
-        specifier: 0.6.2
+        specifier: workspace:*
         version: link:../../../packages/solid-pacer-devtools
       solid-js:
         specifier: ^1.9.12
@@ -4044,7 +4056,7 @@ importers:
   examples/solid/createRateLimitedSignal:
     dependencies:
       '@tanstack/solid-pacer':
-        specifier: ^0.21.0
+        specifier: workspace:*
         version: link:../../../packages/solid-pacer
       solid-js:
         specifier: ^1.9.12
@@ -4060,7 +4072,7 @@ importers:
   examples/solid/createRateLimitedValue:
     dependencies:
       '@tanstack/solid-pacer':
-        specifier: ^0.21.0
+        specifier: workspace:*
         version: link:../../../packages/solid-pacer
       solid-js:
         specifier: ^1.9.12
@@ -4076,7 +4088,7 @@ importers:
   examples/solid/createRateLimiter:
     dependencies:
       '@tanstack/solid-pacer':
-        specifier: ^0.21.0
+        specifier: workspace:*
         version: link:../../../packages/solid-pacer
       solid-js:
         specifier: ^1.9.12
@@ -4092,7 +4104,7 @@ importers:
   examples/solid/createThrottledSignal:
     dependencies:
       '@tanstack/solid-pacer':
-        specifier: ^0.21.0
+        specifier: workspace:*
         version: link:../../../packages/solid-pacer
       solid-js:
         specifier: ^1.9.12
@@ -4108,7 +4120,7 @@ importers:
   examples/solid/createThrottledValue:
     dependencies:
       '@tanstack/solid-pacer':
-        specifier: ^0.21.0
+        specifier: workspace:*
         version: link:../../../packages/solid-pacer
       solid-js:
         specifier: ^1.9.12
@@ -4124,7 +4136,7 @@ importers:
   examples/solid/createThrottler:
     dependencies:
       '@tanstack/solid-pacer':
-        specifier: ^0.21.0
+        specifier: workspace:*
         version: link:../../../packages/solid-pacer
       solid-js:
         specifier: ^1.9.12
@@ -4140,7 +4152,7 @@ importers:
   examples/solid/debounce:
     dependencies:
       '@tanstack/solid-pacer':
-        specifier: ^0.21.0
+        specifier: workspace:*
         version: link:../../../packages/solid-pacer
       solid-js:
         specifier: ^1.9.12
@@ -4159,10 +4171,10 @@ importers:
         specifier: 0.8.2
         version: 0.8.2(csstype@3.2.3)(solid-js@1.9.12)
       '@tanstack/solid-pacer':
-        specifier: ^0.21.0
+        specifier: workspace:*
         version: link:../../../packages/solid-pacer
       '@tanstack/solid-pacer-devtools':
-        specifier: 0.6.2
+        specifier: workspace:*
         version: link:../../../packages/solid-pacer-devtools
       solid-js:
         specifier: ^1.9.12
@@ -4178,7 +4190,7 @@ importers:
   examples/solid/rateLimit:
     dependencies:
       '@tanstack/solid-pacer':
-        specifier: ^0.21.0
+        specifier: workspace:*
         version: link:../../../packages/solid-pacer
       solid-js:
         specifier: ^1.9.12
@@ -4194,7 +4206,7 @@ importers:
   examples/solid/throttle:
     dependencies:
       '@tanstack/solid-pacer':
-        specifier: ^0.21.0
+        specifier: workspace:*
         version: link:../../../packages/solid-pacer
       solid-js:
         specifier: ^1.9.12
@@ -4210,7 +4222,7 @@ importers:
   examples/vanilla/LiteBatcher:
     dependencies:
       '@tanstack/pacer-lite':
-        specifier: 0.2.1
+        specifier: workspace:*
         version: link:../../../packages/pacer-lite
     devDependencies:
       vite:
@@ -4220,7 +4232,7 @@ importers:
   examples/vanilla/LiteDebouncer:
     dependencies:
       '@tanstack/pacer-lite':
-        specifier: 0.2.1
+        specifier: workspace:*
         version: link:../../../packages/pacer-lite
     devDependencies:
       vite:
@@ -4230,7 +4242,7 @@ importers:
   examples/vanilla/LiteQueuer:
     dependencies:
       '@tanstack/pacer-lite':
-        specifier: 0.2.1
+        specifier: workspace:*
         version: link:../../../packages/pacer-lite
     devDependencies:
       vite:
@@ -4240,7 +4252,7 @@ importers:
   examples/vanilla/LiteRateLimiter:
     dependencies:
       '@tanstack/pacer-lite':
-        specifier: 0.2.1
+        specifier: workspace:*
         version: link:../../../packages/pacer-lite
     devDependencies:
       vite:
@@ -4250,7 +4262,7 @@ importers:
   examples/vanilla/LiteThrottler:
     dependencies:
       '@tanstack/pacer-lite':
-        specifier: 0.2.1
+        specifier: workspace:*
         version: link:../../../packages/pacer-lite
     devDependencies:
       vite:
@@ -4260,7 +4272,7 @@ importers:
   examples/vanilla/liteBatch:
     dependencies:
       '@tanstack/pacer-lite':
-        specifier: 0.2.1
+        specifier: workspace:*
         version: link:../../../packages/pacer-lite
     devDependencies:
       vite:
@@ -4270,7 +4282,7 @@ importers:
   examples/vanilla/liteDebounce:
     dependencies:
       '@tanstack/pacer-lite':
-        specifier: 0.2.1
+        specifier: workspace:*
         version: link:../../../packages/pacer-lite
     devDependencies:
       vite:
@@ -4280,7 +4292,7 @@ importers:
   examples/vanilla/liteQueue:
     dependencies:
       '@tanstack/pacer-lite':
-        specifier: 0.2.1
+        specifier: workspace:*
         version: link:../../../packages/pacer-lite
     devDependencies:
       vite:
@@ -4290,7 +4302,7 @@ importers:
   examples/vanilla/liteRateLimit:
     dependencies:
       '@tanstack/pacer-lite':
-        specifier: 0.2.1
+        specifier: workspace:*
         version: link:../../../packages/pacer-lite
     devDependencies:
       vite:
@@ -4300,7 +4312,7 @@ importers:
   examples/vanilla/liteThrottle:
     dependencies:
       '@tanstack/pacer-lite':
-        specifier: 0.2.1
+        specifier: workspace:*
         version: link:../../../packages/pacer-lite
     devDependencies:
       vite:
@@ -4341,7 +4353,7 @@ importers:
         specifier: ^0.4.0
         version: 0.4.0(@types/react@19.2.14)(preact@10.29.1)(react@19.2.6)(solid-js@1.9.12)
       '@tanstack/pacer':
-        specifier: '>=0.16.4'
+        specifier: workspace:*
         version: link:../pacer
       '@tanstack/solid-store':
         specifier: ^0.11.0
@@ -4367,7 +4379,7 @@ importers:
         version: 0.2.1(rolldown@1.0.0)(solid-js@1.9.12)
       tsdown:
         specifier: ^0.22.0
-        version: 0.22.0(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(publint@0.3.20)(typescript@6.0.3)(unrun@0.2.37)
+        version: 0.22.0(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(publint@0.3.20)(typescript@6.0.3)
       vite-plugin-solid:
         specifier: ^2.11.12
         version: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.12)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.97.3)(yaml@2.8.3))
@@ -6234,9 +6246,6 @@ packages:
   '@oxc-project/types@0.113.0':
     resolution: {integrity: sha512-Tp3XmgxwNQ9pEN9vxgJBAqdRamHibi76iowQ38O2I4PMpcvNRQNVsU2n1x1nv9yh0XoTrGFzf7cZSGxmixxrhA==}
 
-  '@oxc-project/types@0.127.0':
-    resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
-
   '@oxc-project/types@0.128.0':
     resolution: {integrity: sha512-huv1Y/LzBJkBVHt3OlC7u0zHBW9qXf1FdD7sGmc1rXc2P1mTwHssYv7jyGx5KAACSCH+9B3Bhn6Z9luHRvf7pQ==}
 
@@ -6478,12 +6487,6 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.17':
-    resolution: {integrity: sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [android]
-
   '@rolldown/binding-android-arm64@1.0.0-rc.18':
     resolution: {integrity: sha512-lIDyUAfD7U3+BWKzdxMbJcsYHuqXqmGz40aeRqvuAm3y5TkJSYTBW2RDrn65DJFPQqVjUAUqq5uz8urzQ8aBdQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -6498,12 +6501,6 @@ packages:
 
   '@rolldown/binding-darwin-arm64@1.0.0':
     resolution: {integrity: sha512-6XcD+8k0gPVItNagEw78/qqcBDwKcwDYS8V2hRmVsfUSIrd8cWe/CBvRDI5toqFyPfj+FJr6t8U6Xj2P2prEew==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
-    resolution: {integrity: sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
@@ -6526,12 +6523,6 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
-    resolution: {integrity: sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [darwin]
-
   '@rolldown/binding-darwin-x64@1.0.0-rc.18':
     resolution: {integrity: sha512-5Ofot8xbs+pxRHJqm9/9N/4sTQOvdrwEsmPE9pdLEEoAbdZtG6F2LMDfO1sp6ZAtXJuJV/21ew2srq3W8NXB5g==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -6546,12 +6537,6 @@ packages:
 
   '@rolldown/binding-freebsd-x64@1.0.0':
     resolution: {integrity: sha512-jjQMDvvwSOuhOwMszD/klSOjyWMM3zI64hWTj9KT5x4MxRbZAf+7vLQ6qouRhtsLVFHr3f0ILaJAfgENPiQdAQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
-    resolution: {integrity: sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
@@ -6574,12 +6559,6 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
-    resolution: {integrity: sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [linux]
-
   '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.18':
     resolution: {integrity: sha512-eRcm/HVt9U/JFu5RKAEKwGQYtDCKWLiaH6wOnsSEp6NMBb/3Os8LgHZlNyzMpFVNmiiMFlfb2zEnebfzJrHFmg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -6594,13 +6573,6 @@ packages:
 
   '@rolldown/binding-linux-arm64-gnu@1.0.0':
     resolution: {integrity: sha512-n7Ofp0mx+aB2cC+Sdy5YtMnXtY9lchnHbY+3Yt0uq9JsWQExf4f5Whu0tK0R8Jdc9S6RchTHjIFY7uc92puOVQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
-    resolution: {integrity: sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -6627,13 +6599,6 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
-    resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.18':
     resolution: {integrity: sha512-QWjdxN1HJCpBTAcZ5N5F7wju3gVPzRzSpmGzx7na0c/1qpN9CFil+xt+l9lV/1M6/gqHSNXCiqPfwhVJPeLnug==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -6655,13 +6620,6 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
-    resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.18':
     resolution: {integrity: sha512-ugCOyj7a4d9h3q9B+wXmf6g3a68UsjGh6dob5DHevHGMwDUbhsYNbSPxJsENcIttJZ9jv7qGM2UesLw5jqIhdg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -6676,13 +6634,6 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
-    resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.18':
     resolution: {integrity: sha512-kKWRhbsotpXkGbcd5dllUWg5gEXcDAa8u5YnP9AV5DYNbvJHGzzuwv7dpmhc8NqKMJldl0a+x76IHbspEpEmdA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -6692,13 +6643,6 @@ packages:
 
   '@rolldown/binding-linux-x64-gnu@1.0.0':
     resolution: {integrity: sha512-Dfn7iak9BcMMePxcoJfpSbWqnEyrp/dRF63/8qW/eHBdOZov6x5aShLLEYGYdIeSJ6vMLK/XCVB+lGIxm41bQA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
-    resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -6725,13 +6669,6 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
-    resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.18':
     resolution: {integrity: sha512-XNOQZtuE6yUIvx4rwGemwh8kpL1xvU41FXy/s9K7T/3JVcqGzo3NfKM2HrbrGgfPYGFW42f07Wk++aOC6B9NWA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -6748,12 +6685,6 @@ packages:
 
   '@rolldown/binding-openharmony-arm64@1.0.0':
     resolution: {integrity: sha512-ouJs8VcUomfLfpbUECqFMRqdV4x6aeAK3MA4m6vTrJJjKyWTV5KnxZx7Jd9G+GlDaQQxubcba00x16OyJ1meig==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [openharmony]
-
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
-    resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
@@ -6775,11 +6706,6 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
-    resolution: {integrity: sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [wasm32]
-
   '@rolldown/binding-wasm32-wasi@1.0.0-rc.18':
     resolution: {integrity: sha512-+J9YGmc+czgqlhYmwun3S3O0FIZhsH8ep2456xwjAdIOmuJxM7xz4P4PtrxU+Bz17a/5bqPA8o3HAAoX0teUdg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -6792,12 +6718,6 @@ packages:
 
   '@rolldown/binding-win32-arm64-msvc@1.0.0':
     resolution: {integrity: sha512-yYK02n8Rngo+gbm1y6G0+7jk1sJ/2Wt7K0me0Y7k/ErBpyf+LJ2gFpqWVTcRV1rUepBlQRmpgWkTQCiiwrK0Ow==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [win32]
-
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
-    resolution: {integrity: sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
@@ -6820,12 +6740,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
-    resolution: {integrity: sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [win32]
-
   '@rolldown/binding-win32-x64-msvc@1.0.0-rc.18':
     resolution: {integrity: sha512-7H+3yqGgmnlDTRRhw/xpYY9J1kf4GC681nVc4GqKhExZTDrVVrV2tsOR9kso0fvgBdcTCcQShx4SLLoHgaLwhg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -6840,9 +6754,6 @@ packages:
 
   '@rolldown/pluginutils@1.0.0':
     resolution: {integrity: sha512-aKs/3GSWyV0mrhNmt/96/Z3yczC3yvrzYATCiCXQebBsGyYzjNdUphRVLeJQ67ySKVXRfMxt2lm12pmXvbPFQQ==}
-
-  '@rolldown/pluginutils@1.0.0-rc.17':
-    resolution: {integrity: sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==}
 
   '@rolldown/pluginutils@1.0.0-rc.18':
     resolution: {integrity: sha512-CUY5Mnhe64xQBGZEEXQ5WyZwsc1JU3vAZLIxtrsBt3LO6UOb+C8GunVKqe9sT8NeWb4lqSaoJtp2xo6GxT1MNw==}
@@ -9708,11 +9619,6 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
-  rolldown@1.0.0-rc.17:
-    resolution: {integrity: sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-
   rolldown@1.0.0-rc.18:
     resolution: {integrity: sha512-phmyKBpuBdRYDf4hgyynGAYn/rDDe+iZXKVJ7WX5b1zQzpLkP5oJRPGsfJuHdzPMlyyEO/4sPW6yfSx2gf7lVg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -10239,16 +10145,6 @@ packages:
 
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
-
-  unrun@0.2.37:
-    resolution: {integrity: sha512-AA7vDuYsgeSYVzJMm16UKA+aXFKhy7nFqW9z5l7q44K4ppFWZAMqYS58ePRZbugMLPH0fwwMzD5A8nP0avxwZQ==}
-    engines: {node: '>=20.19.0'}
-    hasBin: true
-    peerDependencies:
-      synckit: ^0.11.11
-    peerDependenciesMeta:
-      synckit:
-        optional: true
 
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
@@ -12221,9 +12117,6 @@ snapshots:
 
   '@oxc-project/types@0.113.0': {}
 
-  '@oxc-project/types@0.127.0':
-    optional: true
-
   '@oxc-project/types@0.128.0': {}
 
   '@oxc-project/types@0.129.0': {}
@@ -12404,9 +12297,6 @@ snapshots:
   '@rolldown/binding-android-arm64@1.0.0':
     optional: true
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.17':
-    optional: true
-
   '@rolldown/binding-android-arm64@1.0.0-rc.18':
     optional: true
 
@@ -12414,9 +12304,6 @@ snapshots:
     optional: true
 
   '@rolldown/binding-darwin-arm64@1.0.0':
-    optional: true
-
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
     optional: true
 
   '@rolldown/binding-darwin-arm64@1.0.0-rc.18':
@@ -12428,9 +12315,6 @@ snapshots:
   '@rolldown/binding-darwin-x64@1.0.0':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
-    optional: true
-
   '@rolldown/binding-darwin-x64@1.0.0-rc.18':
     optional: true
 
@@ -12438,9 +12322,6 @@ snapshots:
     optional: true
 
   '@rolldown/binding-freebsd-x64@1.0.0':
-    optional: true
-
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
     optional: true
 
   '@rolldown/binding-freebsd-x64@1.0.0-rc.18':
@@ -12452,9 +12333,6 @@ snapshots:
   '@rolldown/binding-linux-arm-gnueabihf@1.0.0':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
-    optional: true
-
   '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.18':
     optional: true
 
@@ -12462,9 +12340,6 @@ snapshots:
     optional: true
 
   '@rolldown/binding-linux-arm64-gnu@1.0.0':
-    optional: true
-
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
     optional: true
 
   '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.18':
@@ -12476,9 +12351,6 @@ snapshots:
   '@rolldown/binding-linux-arm64-musl@1.0.0':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
-    optional: true
-
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.18':
     optional: true
 
@@ -12488,25 +12360,16 @@ snapshots:
   '@rolldown/binding-linux-ppc64-gnu@1.0.0':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
-    optional: true
-
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.18':
     optional: true
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
-    optional: true
-
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.18':
     optional: true
 
   '@rolldown/binding-linux-x64-gnu@1.0.0':
-    optional: true
-
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
     optional: true
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.18':
@@ -12518,9 +12381,6 @@ snapshots:
   '@rolldown/binding-linux-x64-musl@1.0.0':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
-    optional: true
-
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.18':
     optional: true
 
@@ -12530,9 +12390,6 @@ snapshots:
   '@rolldown/binding-openharmony-arm64@1.0.0':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
-    optional: true
-
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.18':
     optional: true
 
@@ -12540,13 +12397,6 @@ snapshots:
     optional: true
 
   '@rolldown/binding-wasm32-wasi@1.0.0':
-    dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-    optional: true
-
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
@@ -12571,9 +12421,6 @@ snapshots:
   '@rolldown/binding-win32-arm64-msvc@1.0.0':
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
-    optional: true
-
   '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.18':
     optional: true
 
@@ -12583,9 +12430,6 @@ snapshots:
   '@rolldown/binding-win32-x64-msvc@1.0.0':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
-    optional: true
-
   '@rolldown/binding-win32-x64-msvc@1.0.0-rc.18':
     optional: true
 
@@ -12593,9 +12437,6 @@ snapshots:
     optional: true
 
   '@rolldown/pluginutils@1.0.0': {}
-
-  '@rolldown/pluginutils@1.0.0-rc.17':
-    optional: true
 
   '@rolldown/pluginutils@1.0.0-rc.18': {}
 
@@ -15794,28 +15635,6 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.0.0
       '@rolldown/binding-win32-x64-msvc': 1.0.0
 
-  rolldown@1.0.0-rc.17:
-    dependencies:
-      '@oxc-project/types': 0.127.0
-      '@rolldown/pluginutils': 1.0.0-rc.17
-    optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.0-rc.17
-      '@rolldown/binding-darwin-arm64': 1.0.0-rc.17
-      '@rolldown/binding-darwin-x64': 1.0.0-rc.17
-      '@rolldown/binding-freebsd-x64': 1.0.0-rc.17
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.17
-      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.17
-      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.17
-      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.17
-      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.17
-      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.17
-      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.17
-      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.17
-      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.17
-      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.17
-      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.17
-    optional: true
-
   rolldown@1.0.0-rc.18:
     dependencies:
       '@oxc-project/types': 0.128.0
@@ -16324,7 +16143,7 @@ snapshots:
       minimist: 1.2.8
       strip-bom: 3.0.0
 
-  tsdown@0.22.0(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(publint@0.3.20)(typescript@6.0.3)(unrun@0.2.37):
+  tsdown@0.22.0(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(publint@0.3.20)(typescript@6.0.3):
     dependencies:
       ansis: 4.2.0
       cac: 7.0.0
@@ -16344,7 +16163,6 @@ snapshots:
     optionalDependencies:
       publint: 0.3.20
       typescript: 6.0.3
-      unrun: 0.2.37
     transitivePeerDependencies:
       - '@ts-macro/tsc'
       - '@typescript/native-preview'
@@ -16444,11 +16262,6 @@ snapshots:
       '@unrs/resolver-binding-win32-arm64-msvc': 1.11.1
       '@unrs/resolver-binding-win32-ia32-msvc': 1.11.1
       '@unrs/resolver-binding-win32-x64-msvc': 1.11.1
-
-  unrun@0.2.37:
-    dependencies:
-      rolldown: 1.0.0-rc.17
-    optional: true
 
   update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,6 +6,18 @@ packages:
   - 'examples/**/*'
   - 'packages/*'
 
+overrides:
+  '@tanstack/angular-pacer': 'workspace:*'
+  '@tanstack/pacer': 'workspace:*'
+  '@tanstack/pacer-devtools': 'workspace:*'
+  '@tanstack/pacer-lite': 'workspace:*'
+  '@tanstack/preact-pacer': 'workspace:*'
+  '@tanstack/preact-pacer-devtools': 'workspace:*'
+  '@tanstack/react-pacer': 'workspace:*'
+  '@tanstack/react-pacer-devtools': 'workspace:*'
+  '@tanstack/solid-pacer': 'workspace:*'
+  '@tanstack/solid-pacer-devtools': 'workspace:*'
+
 allowBuilds:
   # root dependency
   nx: true


### PR DESCRIPTION
sorry, I missed the overrides in the package.json. V11 silently drops them if provided in the package.json, as opposed to the workspace.yaml 