### PR TITLE
fix(async-retryer): preserve non-Error message and cause in normalized errors

### DIFF
--- a/.changeset/big-bikes-wash.md
+++ b/.changeset/big-bikes-wash.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/pacer': patch
+---
+
+Fix AsyncRetryer error normalization to preserve plain-object message values and attach the original thrown value as cause.

--- a/packages/pacer/src/async-retryer.ts
+++ b/packages/pacer/src/async-retryer.ts
@@ -538,7 +538,17 @@ export class AsyncRetryer<TFn extends AnyAsyncFunction> {
         ) {
           return undefined
         }
-        lastError = error instanceof Error ? error : new Error(String(error))
+        lastError =
+          error instanceof Error
+            ? error
+            : new Error(
+                typeof error === 'object' &&
+                  error !== null &&
+                  typeof (error as any).message === 'string'
+                  ? (error as any).message
+                  : String(error),
+                { cause: error },
+              )
         this.#setState({ lastError })
 
         // Call onError for every error (including during retries)

--- a/packages/pacer/tests/async-retryer.test.ts
+++ b/packages/pacer/tests/async-retryer.test.ts
@@ -387,6 +387,24 @@ describe('AsyncRetryer', () => {
       expect(onLastError).toHaveBeenCalledTimes(1)
       expect(onLastError).toHaveBeenCalledWith(error, retryer)
     })
+
+    it('should preserve plain object error message and cause', async () => {
+      const originalError = { message: 'readable error', code: 'E001' }
+      const mockFn = vi.fn().mockRejectedValue(originalError)
+      const retryer = new AsyncRetryer(mockFn, {
+        maxAttempts: 1,
+        throwOnError: true,
+      })
+
+      try {
+        await retryer.execute()
+        expect.unreachable('Expected execute to throw')
+      } catch (error) {
+        expect(error).toBeInstanceOf(Error)
+        expect((error as Error).message).toBe('readable error')
+        expect((error as Error & { cause?: unknown }).cause).toBe(originalError)
+      }
+    })
   })
 
   describe('State Management', () => {


### PR DESCRIPTION
## 🎯 Changes

- Fix AsyncRetryer error normalization for non-Error throws.
- Preserve readable message when a plain object with a string message field is thrown.
- Attach the original thrown value as Error.cause.
- Add regression coverage to ensure:
  - message is preserved as "readable error"
  - cause equals the original thrown object

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/pacer/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with pnpm run test:pr.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during retry operations by better normalizing non-Error thrown values. Error messages from plain objects are now properly preserved, and the original thrown value is accessible via the error cause property. This enables superior error tracking and debugging capabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/pacer/pull/223?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->