### PR TITLE
chore: migrate to pnpm 11.9

### DIFF
--- a/examples/angular/asyncBatch/package.json
+++ b/examples/angular/asyncBatch/package.json
@@ -20,7 +20,7 @@
     ]
   },
   "private": true,
-  "packageManager": "pnpm@11.1.1",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^21.2.12",
     "@angular/compiler": "^21.2.12",

--- a/examples/angular/asyncDebounce/package.json
+++ b/examples/angular/asyncDebounce/package.json
@@ -20,7 +20,7 @@
     ]
   },
   "private": true,
-  "packageManager": "pnpm@11.1.1",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^21.2.12",
     "@angular/compiler": "^21.2.12",

--- a/examples/angular/asyncRateLimit/package.json
+++ b/examples/angular/asyncRateLimit/package.json
@@ -20,7 +20,7 @@
     ]
   },
   "private": true,
-  "packageManager": "pnpm@11.1.1",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^21.2.12",
     "@angular/compiler": "^21.2.12",

--- a/examples/angular/asyncRetry/package.json
+++ b/examples/angular/asyncRetry/package.json
@@ -20,7 +20,7 @@
     ]
   },
   "private": true,
-  "packageManager": "pnpm@11.1.1",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^21.2.12",
     "@angular/compiler": "^21.2.12",

--- a/examples/angular/asyncThrottle/package.json
+++ b/examples/angular/asyncThrottle/package.json
@@ -20,7 +20,7 @@
     ]
   },
   "private": true,
-  "packageManager": "pnpm@11.1.1",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^21.2.12",
     "@angular/compiler": "^21.2.12",

--- a/examples/angular/batch/package.json
+++ b/examples/angular/batch/package.json
@@ -20,7 +20,7 @@
     ]
   },
   "private": true,
-  "packageManager": "pnpm@11.1.1",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^21.2.12",
     "@angular/compiler": "^21.2.12",

--- a/examples/angular/debounce/package.json
+++ b/examples/angular/debounce/package.json
@@ -20,7 +20,7 @@
     ]
   },
   "private": true,
-  "packageManager": "pnpm@11.1.1",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^21.2.12",
     "@angular/compiler": "^21.2.12",

--- a/examples/angular/injectAsyncBatchedCallback/package.json
+++ b/examples/angular/injectAsyncBatchedCallback/package.json
@@ -20,7 +20,7 @@
     ]
   },
   "private": true,
-  "packageManager": "pnpm@11.1.1",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^21.2.12",
     "@angular/compiler": "^21.2.12",

--- a/examples/angular/injectAsyncBatcher/package.json
+++ b/examples/angular/injectAsyncBatcher/package.json
@@ -20,7 +20,7 @@
     ]
   },
   "private": true,
-  "packageManager": "pnpm@11.1.1",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^21.2.12",
     "@angular/compiler": "^21.2.12",

--- a/examples/angular/injectAsyncDebouncedCallback/package.json
+++ b/examples/angular/injectAsyncDebouncedCallback/package.json
@@ -20,7 +20,7 @@
     ]
   },
   "private": true,
-  "packageManager": "pnpm@11.1.1",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^21.2.12",
     "@angular/compiler": "^21.2.12",

--- a/examples/angular/injectAsyncDebouncer/package.json
+++ b/examples/angular/injectAsyncDebouncer/package.json
@@ -20,7 +20,7 @@
     ]
   },
   "private": true,
-  "packageManager": "pnpm@11.1.1",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^21.2.12",
     "@angular/compiler": "^21.2.12",

--- a/examples/angular/injectAsyncQueuedSignal/package.json
+++ b/examples/angular/injectAsyncQueuedSignal/package.json
@@ -20,7 +20,7 @@
     ]
   },
   "private": true,
-  "packageManager": "pnpm@11.1.1",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^21.2.12",
     "@angular/compiler": "^21.2.12",

--- a/examples/angular/injectAsyncQueuer/package.json
+++ b/examples/angular/injectAsyncQueuer/package.json
@@ -20,7 +20,7 @@
     ]
   },
   "private": true,
-  "packageManager": "pnpm@11.1.1",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^21.2.12",
     "@angular/compiler": "^21.2.12",

--- a/examples/angular/injectAsyncRateLimiter/package.json
+++ b/examples/angular/injectAsyncRateLimiter/package.json
@@ -20,7 +20,7 @@
     ]
   },
   "private": true,
-  "packageManager": "pnpm@11.1.1",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^21.2.12",
     "@angular/compiler": "^21.2.12",

--- a/examples/angular/injectAsyncRateLimiterWithPersister/package.json
+++ b/examples/angular/injectAsyncRateLimiterWithPersister/package.json
@@ -20,7 +20,7 @@
     ]
   },
   "private": true,
-  "packageManager": "pnpm@11.1.1",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^21.2.12",
     "@angular/compiler": "^21.2.12",

--- a/examples/angular/injectAsyncThrottledCallback/package.json
+++ b/examples/angular/injectAsyncThrottledCallback/package.json
@@ -20,7 +20,7 @@
     ]
   },
   "private": true,
-  "packageManager": "pnpm@11.1.1",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^21.2.12",
     "@angular/compiler": "^21.2.12",

--- a/examples/angular/injectAsyncThrottler/package.json
+++ b/examples/angular/injectAsyncThrottler/package.json
@@ -20,7 +20,7 @@
     ]
   },
   "private": true,
-  "packageManager": "pnpm@11.1.1",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^21.2.12",
     "@angular/compiler": "^21.2.12",

--- a/examples/angular/injectBatchedCallback/package.json
+++ b/examples/angular/injectBatchedCallback/package.json
@@ -20,7 +20,7 @@
     ]
   },
   "private": true,
-  "packageManager": "pnpm@11.1.1",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^21.2.12",
     "@angular/compiler": "^21.2.12",

--- a/examples/angular/injectBatcher/package.json
+++ b/examples/angular/injectBatcher/package.json
@@ -20,7 +20,7 @@
     ]
   },
   "private": true,
-  "packageManager": "pnpm@11.1.1",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^21.2.12",
     "@angular/compiler": "^21.2.12",

--- a/examples/angular/injectDebouncedCallback/package.json
+++ b/examples/angular/injectDebouncedCallback/package.json
@@ -20,7 +20,7 @@
     ]
   },
   "private": true,
-  "packageManager": "pnpm@11.1.1",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^21.2.12",
     "@angular/compiler": "^21.2.12",

--- a/examples/angular/injectDebouncedSignal/package.json
+++ b/examples/angular/injectDebouncedSignal/package.json
@@ -20,7 +20,7 @@
     ]
   },
   "private": true,
-  "packageManager": "pnpm@11.1.1",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^21.2.12",
     "@angular/compiler": "^21.2.12",

--- a/examples/angular/injectDebouncedValue/package.json
+++ b/examples/angular/injectDebouncedValue/package.json
@@ -20,7 +20,7 @@
     ]
   },
   "private": true,
-  "packageManager": "pnpm@11.1.1",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^21.2.12",
     "@angular/compiler": "^21.2.12",

--- a/examples/angular/injectDebouncer/package.json
+++ b/examples/angular/injectDebouncer/package.json
@@ -20,7 +20,7 @@
     ]
   },
   "private": true,
-  "packageManager": "pnpm@11.1.1",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^21.2.12",
     "@angular/compiler": "^21.2.12",

--- a/examples/angular/injectQueuedSignal/package.json
+++ b/examples/angular/injectQueuedSignal/package.json
@@ -20,7 +20,7 @@
     ]
   },
   "private": true,
-  "packageManager": "pnpm@11.1.1",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^21.2.12",
     "@angular/compiler": "^21.2.12",

--- a/examples/angular/injectQueuedValue/package.json
+++ b/examples/angular/injectQueuedValue/package.json
@@ -20,7 +20,7 @@
     ]
   },
   "private": true,
-  "packageManager": "pnpm@11.1.1",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^21.2.12",
     "@angular/compiler": "^21.2.12",

--- a/examples/angular/injectQueuer/package.json
+++ b/examples/angular/injectQueuer/package.json
@@ -20,7 +20,7 @@
     ]
   },
   "private": true,
-  "packageManager": "pnpm@11.1.1",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^21.2.12",
     "@angular/compiler": "^21.2.12",

--- a/examples/angular/injectQueuerWithPersister/package.json
+++ b/examples/angular/injectQueuerWithPersister/package.json
@@ -20,7 +20,7 @@
     ]
   },
   "private": true,
-  "packageManager": "pnpm@11.1.1",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^21.2.12",
     "@angular/compiler": "^21.2.12",

--- a/examples/angular/injectRateLimitedCallback/package.json
+++ b/examples/angular/injectRateLimitedCallback/package.json
@@ -20,7 +20,7 @@
     ]
   },
   "private": true,
-  "packageManager": "pnpm@11.1.1",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^21.2.12",
     "@angular/compiler": "^21.2.12",

--- a/examples/angular/injectRateLimitedSignal/package.json
+++ b/examples/angular/injectRateLimitedSignal/package.json
@@ -20,7 +20,7 @@
     ]
   },
   "private": true,
-  "packageManager": "pnpm@11.1.1",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^21.2.12",
     "@angular/compiler": "^21.2.12",

--- a/examples/angular/injectRateLimitedValue/package.json
+++ b/examples/angular/injectRateLimitedValue/package.json
@@ -20,7 +20,7 @@
     ]
   },
   "private": true,
-  "packageManager": "pnpm@11.1.1",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^21.2.12",
     "@angular/compiler": "^21.2.12",

--- a/examples/angular/injectRateLimiter/package.json
+++ b/examples/angular/injectRateLimiter/package.json
@@ -20,7 +20,7 @@
     ]
   },
   "private": true,
-  "packageManager": "pnpm@11.1.1",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^21.2.12",
     "@angular/compiler": "^21.2.12",

--- a/examples/angular/injectRateLimiterWithPersister/package.json
+++ b/examples/angular/injectRateLimiterWithPersister/package.json
@@ -20,7 +20,7 @@
     ]
   },
   "private": true,
-  "packageManager": "pnpm@11.1.1",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^21.2.12",
     "@angular/compiler": "^21.2.12",

--- a/examples/angular/injectThrottledCallback/package.json
+++ b/examples/angular/injectThrottledCallback/package.json
@@ -20,7 +20,7 @@
     ]
   },
   "private": true,
-  "packageManager": "pnpm@11.1.1",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^21.2.12",
     "@angular/compiler": "^21.2.12",

--- a/examples/angular/injectThrottledSignal/package.json
+++ b/examples/angular/injectThrottledSignal/package.json
@@ -20,7 +20,7 @@
     ]
   },
   "private": true,
-  "packageManager": "pnpm@11.1.1",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^21.2.12",
     "@angular/compiler": "^21.2.12",

--- a/examples/angular/injectThrottledValue/package.json
+++ b/examples/angular/injectThrottledValue/package.json
@@ -20,7 +20,7 @@
     ]
   },
   "private": true,
-  "packageManager": "pnpm@11.1.1",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^21.2.12",
     "@angular/compiler": "^21.2.12",

--- a/examples/angular/injectThrottler/package.json
+++ b/examples/angular/injectThrottler/package.json
@@ -20,7 +20,7 @@
     ]
   },
   "private": true,
-  "packageManager": "pnpm@11.1.1",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^21.2.12",
     "@angular/compiler": "^21.2.12",

--- a/examples/angular/queue/package.json
+++ b/examples/angular/queue/package.json
@@ -20,7 +20,7 @@
     ]
   },
   "private": true,
-  "packageManager": "pnpm@11.1.1",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^21.2.12",
     "@angular/compiler": "^21.2.12",

--- a/examples/angular/rateLimit/package.json
+++ b/examples/angular/rateLimit/package.json
@@ -20,7 +20,7 @@
     ]
   },
   "private": true,
-  "packageManager": "pnpm@11.1.1",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^21.2.12",
     "@angular/compiler": "^21.2.12",

--- a/examples/angular/throttle/package.json
+++ b/examples/angular/throttle/package.json
@@ -20,7 +20,7 @@
     ]
   },
   "private": true,
-  "packageManager": "pnpm@11.1.1",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^21.2.12",
     "@angular/compiler": "^21.2.12",

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
     "type": "git",
     "url": "git+https://github.com/TanStack/pacer.git"
   },
-  "packageManager": "pnpm@11.1.1",
+  "packageManager": "pnpm@11.9.0",
   "engines": {
-    "pnpm": ">=11.0.0"
+    "pnpm": ">=11.9.0"
   },
   "type": "module",
   "scripts": {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,5 @@
 cleanupUnusedCatalogs: true
-minimumReleaseAge: 1
+minimumReleaseAge: 1440
 linkWorkspacePackages: true
 preferWorkspacePackages: true
 blockExoticSubdeps: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,13 @@
 cleanupUnusedCatalogs: true
+minimumReleaseAge: 1
 linkWorkspacePackages: true
 preferWorkspacePackages: true
+blockExoticSubdeps: true
+trustPolicy: 'no-downgrade'
+
+trustPolicyExclude:
+  - 'chokidar@4.0.3' # Socket score 99; popular and healthy existing watcher dependency
+  - 'semver@6.3.1' # Socket score 100; latest v6 and healthy existing semver dependency
 
 packages:
   - 'examples/**/*'
@@ -28,4 +35,3 @@ allowBuilds:
   '@parcel/watcher': false # optional dep of @angular/build
   lmdb: false # optional dep of @angular/build
   msgpackr-extract: false # optional dep of @angular/build
-


### PR DESCRIPTION
Updates pnpm to 11.9.0 and aligns workspace security settings with the TanStack pnpm 11.9 procedure.

Verification:
- pnpm install --frozen-lockfile --ignore-scripts --trust-lockfile=false
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project and example manifests to use a newer pnpm version.
  * Raised the minimum supported pnpm version to match the new workspace setup.
  * Added workspace package policy settings to improve consistency and control over dependency handling.
  * Adjusted build allowances for a few optional packages in the Angular examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->