### PR TITLE
fix: reset pending state after leading-only debouncer execution

### DIFF
--- a/packages/pacer-lite/src/lite-debouncer.ts
+++ b/packages/pacer-lite/src/lite-debouncer.ts
@@ -99,7 +99,11 @@ export class LiteDebouncer<TFn extends AnyFunction> {
       this.options.onExecute?.(args, this)
     }
 
-    this.lastArgs = args
+    // Only store args that were not already handled by the leading edge,
+    // so a later flush or trailing execution cannot re-execute them
+    if (!didLeadingExecute) {
+      this.lastArgs = args
+    }
 
     if (this.timeoutId) {
       clearTimeout(this.timeoutId)

--- a/packages/pacer-lite/tests/lite-debouncer.test.ts
+++ b/packages/pacer-lite/tests/lite-debouncer.test.ts
@@ -275,6 +275,23 @@ describe('LiteDebouncer', () => {
       expect(mockFn).toHaveBeenLastCalledWith('second')
     })
 
+    it('should not re-execute args already handled by the leading edge', () => {
+      const mockFn = vi.fn()
+      const debouncer = new LiteDebouncer(mockFn, {
+        wait: 1000,
+        leading: true,
+        trailing: true,
+      })
+
+      debouncer.maybeExecute('only-call')
+      expect(mockFn).toBeCalledTimes(1)
+
+      // The single call was fully handled by the leading edge, so flush
+      // must not execute it a second time
+      debouncer.flush()
+      expect(mockFn).toBeCalledTimes(1)
+    })
+
     it('should flush pending execution even with trailing: false', () => {
       const mockFn = vi.fn()
       const debouncer = new LiteDebouncer(mockFn, {

--- a/packages/pacer/src/debouncer.ts
+++ b/packages/pacer/src/debouncer.ts
@@ -232,8 +232,10 @@ export class Debouncer<TFn extends AnyFunction> {
       this.#execute(...args)
     }
 
-    // Start pending state to indicate that the debouncer is waiting for the trailing edge
-    if (this.options.trailing) {
+    // Start pending state to indicate that the debouncer is waiting for the trailing edge.
+    // Skip if this call already executed on the leading edge, since the timeout
+    // will not perform a trailing execution for it.
+    if (this.options.trailing && !_didLeadingExecute) {
       this.#setState({ isPending: true, lastArgs: args })
     }
 

--- a/packages/pacer/tests/debouncer.test.ts
+++ b/packages/pacer/tests/debouncer.test.ts
@@ -261,6 +261,24 @@ describe('Debouncer', () => {
       expect(mockFn).toHaveBeenLastCalledWith('second')
     })
 
+    it('should not re-execute stale args after a single leading execution', () => {
+      const mockFn = vi.fn()
+      const debouncer = new Debouncer(mockFn, {
+        wait: 1000,
+        leading: true,
+        trailing: true,
+      })
+
+      debouncer.maybeExecute('only-call')
+      expect(mockFn).toBeCalledTimes(1)
+      vi.advanceTimersByTime(1000)
+
+      // The single call was fully handled by the leading edge, so there is
+      // nothing pending for flush to execute
+      debouncer.flush()
+      expect(mockFn).toBeCalledTimes(1)
+    })
+
     it('should not work with leading-only execution because there would be no trailing execution to flush', () => {
       const mockFn = vi.fn()
       const debouncer = new Debouncer(mockFn, {
@@ -478,6 +496,27 @@ describe('Debouncer', () => {
 
       vi.advanceTimersByTime(100)
       expect(debouncer.store.state.isPending).toBe(false)
+    })
+
+    it('should not be pending after a single leading-only execution', () => {
+      const mockFn = vi.fn()
+      const debouncer = new Debouncer(mockFn, {
+        wait: 1000,
+        leading: true,
+        trailing: true,
+      })
+
+      // A single call executes on the leading edge; no trailing execution
+      // is owed, so the debouncer should not report itself as pending
+      debouncer.maybeExecute('only-call')
+      expect(mockFn).toBeCalledTimes(1)
+      expect(debouncer.store.state.isPending).toBe(false)
+      expect(debouncer.store.state.lastArgs).toBeUndefined()
+
+      vi.advanceTimersByTime(1000)
+      expect(mockFn).toBeCalledTimes(1)
+      expect(debouncer.store.state.isPending).toBe(false)
+      expect(debouncer.store.state.status).toBe('idle')
     })
 
     it('should not be pending when leading and trailing are both false', () => {


### PR DESCRIPTION
## 🎯 Changes

With `leading: true` and `trailing: true`, a single call to `maybeExecute` executed on the leading edge but still set `isPending: true` and stored `lastArgs`. The trailing timeout correctly skips calls already handled by the leading edge, so nothing ever reset that state: status stayed `'pending'` forever, and a later `flush()` re-executed the function with stale, already-executed arguments.

**Fix**

- Only set `isPending` / `lastArgs` for calls that were **not** consumed by the leading edge, so the debouncer returns to `'idle'` after a single execution.
- Applied the same fix to `LiteDebouncer`, which stored `lastArgs` unconditionally and could therefore re-execute a leading-edge call via `flush()`.

**Tests**

- Added coverage for leading + trailing execution, `flush()` behavior after a leading-edge call, pending state, and idle transitions.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/pacer/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented debounced actions configured for leading and trailing execution from being invoked twice with the same arguments.
  * Improved `flush()` behavior so it no longer re-executes completed leading-edge calls.
  * Corrected pending-state and idle-status handling after a single debounced execution.

* **Tests**
  * Added coverage for leading/trailing execution, `flush()`, pending state, and idle transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
