### PR TITLE
fix: rename `executeCount` to `executionCount` in AsyncBatcherState and AsyncQueuerState

### DIFF
--- a/.changeset/unify-execution-count-naming.md
+++ b/.changeset/unify-execution-count-naming.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/pacer': minor
+---
+
+breaking: rename `executeCount` to `executionCount` in `AsyncBatcherState` and `AsyncQueuerState` for consistency with all other utilities (`BatcherState`, `QueuerState`, `DebouncerState`, `ThrottlerState`, `RateLimiterState`, and `AsyncRetryerState` all use `executionCount`). The `getAbortSignal(executionCount?)` parameter on AsyncBatcher and AsyncQueuer is renamed accordingly. Pure rename, no behavior change — update any state selectors, `initialState` values, or callbacks reading `executeCount` to use `executionCount` (fixes #253)

--- a/docs/framework/angular/guides/async-batching.md
+++ b/docs/framework/angular/guides/async-batching.md
@@ -150,7 +150,7 @@ const batcher = injectAsyncBatcher(
 batcher.abort()
 ```
 
-When executions overlap, pass an `executeCount` to `getAbortSignal()` when you need a specific execution's signal.
+When executions overlap, pass an `executionCount` to `getAbortSignal()` when you need a specific execution's signal.
 
 ### Resetting safely
 

--- a/docs/framework/angular/guides/async-queuing.md
+++ b/docs/framework/angular/guides/async-queuing.md
@@ -166,7 +166,7 @@ const queue = injectAsyncQueuer(
 queue.abort()
 ```
 
-When multiple executions overlap, pass an `executeCount` to `getAbortSignal()` when you need a specific execution's signal.
+When multiple executions overlap, pass an `executionCount` to `getAbortSignal()` when you need a specific execution's signal.
 
 ### Resetting safely
 

--- a/docs/framework/preact/guides/async-batching.md
+++ b/docs/framework/preact/guides/async-batching.md
@@ -156,7 +156,7 @@ const batcher = useAsyncBatcher(
 batcher.abort()
 ```
 
-When executions overlap, pass an `executeCount` to `getAbortSignal()` when you need a specific execution's signal.
+When executions overlap, pass an `executionCount` to `getAbortSignal()` when you need a specific execution's signal.
 
 ### Resetting safely
 

--- a/docs/framework/preact/guides/async-queuing.md
+++ b/docs/framework/preact/guides/async-queuing.md
@@ -168,7 +168,7 @@ const queue = useAsyncQueuer(
 queue.abort()
 ```
 
-When multiple executions overlap, pass an `executeCount` to `getAbortSignal()` when you need a specific execution's signal.
+When multiple executions overlap, pass an `executionCount` to `getAbortSignal()` when you need a specific execution's signal.
 
 ### Resetting safely
 

--- a/docs/framework/react/guides/async-batching.md
+++ b/docs/framework/react/guides/async-batching.md
@@ -156,7 +156,7 @@ const batcher = useAsyncBatcher(
 batcher.abort()
 ```
 
-When executions overlap, pass an `executeCount` to `getAbortSignal()` when you need a specific execution's signal.
+When executions overlap, pass an `executionCount` to `getAbortSignal()` when you need a specific execution's signal.
 
 ### Resetting safely
 

--- a/docs/framework/react/guides/async-queuing.md
+++ b/docs/framework/react/guides/async-queuing.md
@@ -168,7 +168,7 @@ const queue = useAsyncQueuer(
 queue.abort()
 ```
 
-When multiple executions overlap, pass an `executeCount` to `getAbortSignal()` when you need a specific execution's signal.
+When multiple executions overlap, pass an `executionCount` to `getAbortSignal()` when you need a specific execution's signal.
 
 ### Resetting safely
 

--- a/docs/framework/solid/guides/async-batching.md
+++ b/docs/framework/solid/guides/async-batching.md
@@ -150,7 +150,7 @@ const batcher = createAsyncBatcher(
 batcher.abort()
 ```
 
-When executions overlap, pass an `executeCount` to `getAbortSignal()` when you need a specific execution's signal.
+When executions overlap, pass an `executionCount` to `getAbortSignal()` when you need a specific execution's signal.
 
 ### Resetting safely
 

--- a/docs/framework/solid/guides/async-queuing.md
+++ b/docs/framework/solid/guides/async-queuing.md
@@ -158,7 +158,7 @@ const queue = createAsyncQueuer(
 queue.abort()
 ```
 
-When multiple executions overlap, pass an `executeCount` to `getAbortSignal()` when you need a specific execution's signal.
+When multiple executions overlap, pass an `executionCount` to `getAbortSignal()` when you need a specific execution's signal.
 
 ### Resetting safely
 

--- a/docs/framework/vanilla/guides/async-batching.md
+++ b/docs/framework/vanilla/guides/async-batching.md
@@ -168,7 +168,7 @@ const batcher = new AsyncBatcher(
 batcher.abort()
 ```
 
-When executions overlap, pass an `executeCount` to `getAbortSignal()` when you need a specific execution's signal.
+When executions overlap, pass an `executionCount` to `getAbortSignal()` when you need a specific execution's signal.
 
 ### Resetting safely
 

--- a/docs/framework/vanilla/guides/async-queuing.md
+++ b/docs/framework/vanilla/guides/async-queuing.md
@@ -179,7 +179,7 @@ const queue = new AsyncQueuer(
 queue.abort()
 ```
 
-When multiple executions overlap, pass an `executeCount` to `getAbortSignal()` when you need a specific execution's signal.
+When multiple executions overlap, pass an `executionCount` to `getAbortSignal()` when you need a specific execution's signal.
 
 ### Resetting safely
 

--- a/docs/reference/classes/AsyncBatcher.md
+++ b/docs/reference/classes/AsyncBatcher.md
@@ -266,18 +266,18 @@ Processes the current batch of items immediately
 ### getAbortSignal()
 
 ```ts
-getAbortSignal(executeCount?): AbortSignal | null;
+getAbortSignal(executionCount?): AbortSignal | null;
 ```
 
 Defined in: [async-batcher.ts:483](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/async-batcher.ts#L483)
 
 Returns the AbortSignal for a specific execution.
-If no executeCount is provided, returns the signal for the most recent execution.
+If no executionCount is provided, returns the signal for the most recent execution.
 Returns null if no execution is found or not currently executing.
 
 #### Parameters
 
-##### executeCount?
+##### executionCount?
 
 `number`
 

--- a/docs/reference/classes/AsyncQueuer.md
+++ b/docs/reference/classes/AsyncQueuer.md
@@ -321,18 +321,18 @@ The queue is cleared after processing
 ### getAbortSignal()
 
 ```ts
-getAbortSignal(executeCount?): AbortSignal | null;
+getAbortSignal(executionCount?): AbortSignal | null;
 ```
 
 Defined in: [async-queuer.ts:889](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/async-queuer.ts#L889)
 
 Returns the AbortSignal for a specific execution.
-If no executeCount is provided, returns the signal for the most recent execution.
+If no executionCount is provided, returns the signal for the most recent execution.
 Returns null if no execution is found or not currently executing.
 
 #### Parameters
 
-##### executeCount?
+##### executionCount?
 
 `number`
 

--- a/docs/reference/interfaces/AsyncBatcherState.md
+++ b/docs/reference/interfaces/AsyncBatcherState.md
@@ -27,15 +27,15 @@ Number of batch executions that have resulted in errors
 
 ***
 
-### executeCount
+### executionCount
 
 ```ts
-executeCount: number;
+executionCount: number;
 ```
 
 Defined in: [async-batcher.ts:16](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/async-batcher.ts#L16)
 
-Number of batch executions that have been executed
+Number of batch executions that have been started
 
 ***
 

--- a/docs/reference/interfaces/AsyncQueuerState.md
+++ b/docs/reference/interfaces/AsyncQueuerState.md
@@ -51,10 +51,10 @@ Number of task executions that have resulted in errors
 
 ***
 
-### executeCount
+### executionCount
 
 ```ts
-executeCount: number;
+executionCount: number;
 ```
 
 Defined in: [async-queuer.ts:25](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/async-queuer.ts#L25)

--- a/packages/pacer/src/async-batcher.ts
+++ b/packages/pacer/src/async-batcher.ts
@@ -11,9 +11,9 @@ export interface AsyncBatcherState<TValue> {
    */
   errorCount: number
   /**
-   * Number of batch executions that have been executed
+   * Number of batch executions that have been started
    */
-  executeCount: number
+  executionCount: number
   /**
    * Array of items that failed during batch processing
    */
@@ -67,7 +67,7 @@ export interface AsyncBatcherState<TValue> {
 function getDefaultAsyncBatcherState<TValue>(): AsyncBatcherState<TValue> {
   return {
     errorCount: 0,
-    executeCount: 0,
+    executionCount: 0,
     failedItems: [],
     isEmpty: true,
     isExecuting: false,
@@ -380,19 +380,19 @@ export class AsyncBatcher<TValue> {
       return undefined
     }
 
-    const currentExecuteCount = this.store.state.executeCount + 1
+    const currentExecutionCount = this.store.state.executionCount + 1
     const batch = this.peekAllItems() // copy of the items to be processed (to prevent race conditions)
     this.clear() // Clear items before processing to prevent race conditions
     this.options.onItemsChange?.(this)
 
-    this.#setState({ isExecuting: true, executeCount: currentExecuteCount })
+    this.#setState({ isExecuting: true, executionCount: currentExecutionCount })
 
     try {
       const currentAsyncRetryer = new AsyncRetryer(
         this.fn,
         this.options.asyncRetryerOptions,
       )
-      this.asyncRetryers.set(currentExecuteCount, currentAsyncRetryer)
+      this.asyncRetryers.set(currentExecutionCount, currentAsyncRetryer)
       const result = await currentAsyncRetryer.execute(batch) // EXECUTE
       this.#setState({
         totalItemsProcessed:
@@ -414,7 +414,7 @@ export class AsyncBatcher<TValue> {
       }
       return undefined
     } finally {
-      this.asyncRetryers.delete(currentExecuteCount) // dispose retryer
+      this.asyncRetryers.delete(currentExecutionCount) // dispose retryer
       this.#setState({
         isExecuting: false,
         settleCount: this.store.state.settleCount + 1,
@@ -458,10 +458,10 @@ export class AsyncBatcher<TValue> {
 
   /**
    * Returns the AbortSignal for a specific execution.
-   * If no executeCount is provided, returns the signal for the most recent execution.
+   * If no executionCount is provided, returns the signal for the most recent execution.
    * Returns null if no execution is found or not currently executing.
    *
-   * @param executeCount - Optional specific execution to get signal for
+   * @param executionCount - Optional specific execution to get signal for
    * @example
    * ```typescript
    * const batcher = new AsyncBatcher(
@@ -480,8 +480,8 @@ export class AsyncBatcher<TValue> {
    * )
    * ```
    */
-  getAbortSignal = (executeCount?: number): AbortSignal | null => {
-    const count = executeCount ?? this.store.state.executeCount
+  getAbortSignal = (executionCount?: number): AbortSignal | null => {
+    const count = executionCount ?? this.store.state.executionCount
     const retryer = this.asyncRetryers.get(count)
     return retryer?.getAbortSignal() ?? null
   }

--- a/packages/pacer/src/async-queuer.ts
+++ b/packages/pacer/src/async-queuer.ts
@@ -22,7 +22,7 @@ export interface AsyncQueuerState<TValue> {
   /**
    * Number of times execute has been called
    */
-  executeCount: number
+  executionCount: number
   /**
    * Number of items that have been removed from the queue due to expiration
    */
@@ -90,7 +90,7 @@ function getDefaultAsyncQueuerState<TValue>(): AsyncQueuerState<TValue> {
     activeItems: [],
     addItemCount: 0,
     errorCount: 0,
-    executeCount: 0,
+    executionCount: 0,
     expirationCount: 0,
     isEmpty: true,
     isExecuting: false,
@@ -636,9 +636,9 @@ export class AsyncQueuer<TValue> {
     const item = this.getNextItem(position)
 
     if (item !== undefined) {
-      const currentExecuteCount = this.store.state.executeCount + 1
+      const currentExecutionCount = this.store.state.executionCount + 1
       this.#setState({
-        executeCount: currentExecuteCount,
+        executionCount: currentExecutionCount,
         isExecuting: true,
       })
       try {
@@ -646,7 +646,7 @@ export class AsyncQueuer<TValue> {
           this.fn,
           this.options.asyncRetryerOptions,
         )
-        this.asyncRetryers.set(currentExecuteCount, currentAsyncRetryer)
+        this.asyncRetryers.set(currentExecutionCount, currentAsyncRetryer)
         const lastResult = await currentAsyncRetryer.execute(item) // EXECUTE!
         this.#setState({
           successCount: this.store.state.successCount + 1,
@@ -662,7 +662,7 @@ export class AsyncQueuer<TValue> {
           throw error
         }
       } finally {
-        this.asyncRetryers.delete(currentExecuteCount) // dispose retryer
+        this.asyncRetryers.delete(currentExecutionCount) // dispose retryer
         // remove only one occurrence so duplicate item values keep accurate
         // concurrency accounting
         const remainingActiveItems = [...this.store.state.activeItems]
@@ -868,10 +868,10 @@ export class AsyncQueuer<TValue> {
 
   /**
    * Returns the AbortSignal for a specific execution.
-   * If no executeCount is provided, returns the signal for the most recent execution.
+   * If no executionCount is provided, returns the signal for the most recent execution.
    * Returns null if no execution is found or not currently executing.
    *
-   * @param executeCount - Optional specific execution to get signal for
+   * @param executionCount - Optional specific execution to get signal for
    * @example
    * ```typescript
    * const queuer = new AsyncQueuer(
@@ -886,8 +886,8 @@ export class AsyncQueuer<TValue> {
    * )
    * ```
    */
-  getAbortSignal = (executeCount?: number): AbortSignal | null => {
-    const count = executeCount ?? this.store.state.executeCount
+  getAbortSignal = (executionCount?: number): AbortSignal | null => {
+    const count = executionCount ?? this.store.state.executionCount
     const retryer = this.asyncRetryers.get(count)
     return retryer?.getAbortSignal() ?? null
   }


### PR DESCRIPTION
Fixes #253

## What

Renames `executeCount` → `executionCount` in `AsyncBatcherState` and `AsyncQueuerState`, the only two state interfaces that diverged from the `executionCount` name used everywhere else (`BatcherState`, `QueuerState`, `DebouncerState`, `ThrottlerState`, `RateLimiterState`, `AsyncRetryerState`).

Pure rename — no behavior change. The counter still increments at execution start and still serves as the key for the internal `asyncRetryers` map and `getAbortSignal()`.

## Changes

- `packages/pacer/src/async-batcher.ts`, `async-queuer.ts`: state field, `getAbortSignal(executionCount?)` parameter, internal locals, and TSDoc. Also fixed the circular AsyncBatcher field comment ("executions that have been executed" → "executions that have been started", matching the actual increment timing).
- Framework guide docs (async-batching / async-queuing × react, preact, solid, angular, vanilla).
- Regenerated reference docs via `pnpm generate-docs` (only AsyncBatcher/AsyncQueuer pages changed).
- Changeset: **minor** for `@tanstack/pacer`, with the rename called out as breaking in the changelog entry.

`maybeExecuteCount` fields are untouched — they're named after the `maybeExecute` method, which is a different convention.

## Verification

- `pnpm test` (vitest): 555/555 pass in `@tanstack/pacer`; `nx affected --targets=test:lib,test:types` green across all 10 packages.
- `grep -rn executeCount` across packages/docs/examples returns no remaining references (excluding `maybeExecuteCount`).

## Notes for review

- This is technically breaking for anyone reading `state.executeCount` (selectors, `initialState`, devtools-adjacent code). Since Pacer is pre-1.0 I've marked it minor per 0.x semver — happy to adjust if you'd rather stage a deprecation alias instead.

## Follow-up idea (not in this PR): guard against future naming drift with a type test

This divergence went unnoticed because nothing ties the sync and async state interfaces together — they're deliberately independent declarations (which keeps the interfaces flat and doc-generation friendly, so I'm not proposing `extends`). A lightweight alternative that keeps that structure intact: a type-level test asserting that the fields shared between counterpart interfaces keep the same names, e.g.

```ts
// compile error if a shared field is renamed on only one side
type SharedBatcherKeys = 'executionCount' | 'isEmpty' | 'isPending' | 'items' | 'size' | 'totalItemsProcessed'
assertType<SharedBatcherKeys extends keyof AsyncBatcherState<unknown> ? true : false>(true)
assertType<SharedBatcherKeys extends keyof BatcherState<unknown> ? true : false>(true)
```

If maintainers think it's worthwhile, I'd be happy to add such tests for all sync/async counterpart pairs in a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Renamed the async batching and queuing execution counter from `executeCount` to `executionCount`.
  * Renamed the optional `getAbortSignal` parameter to `executionCount`.
  * Update integrations that reference the previous property or parameter name.

* **Documentation**
  * Updated async batching, queuing, and API reference guides across supported frameworks.
  * Clarified that omitting the execution count selects the most recent execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
