### PR TITLE
fix: preserve lastArgs of queued execution (#257)

### DIFF
--- a/.changeset/little-planets-serve.md
+++ b/.changeset/little-planets-serve.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/pacer': patch
+---
+
+Fixed a bug in AsyncDebouncer where a scheduled execution is dropped if an in-flight execution completes before it is invoked

--- a/packages/pacer/src/async-debouncer.ts
+++ b/packages/pacer/src/async-debouncer.ts
@@ -366,7 +366,7 @@ export class AsyncDebouncer<TFn extends AnyAsyncFunction> {
     const currentMaybeExecuteCount = this.store.state.maybeExecuteCount + 1
 
     try {
-      this.#setState({ isExecuting: true })
+      this.#setState({ isExecuting: true, lastArgs: undefined })
       const currentAsyncRetryer = new AsyncRetryer(
         this.fn,
         this.options.asyncRetryerOptions,
@@ -391,7 +391,6 @@ export class AsyncDebouncer<TFn extends AnyAsyncFunction> {
       this.#setState({
         isExecuting: false,
         isPending: false,
-        lastArgs: undefined,
         settleCount: this.store.state.settleCount + 1,
       })
       this.options.onSettled?.(args, this)

--- a/packages/pacer/tests/async-debouncer.test.ts
+++ b/packages/pacer/tests/async-debouncer.test.ts
@@ -237,6 +237,39 @@ describe('AsyncDebouncer', () => {
       expect(mockFn).toHaveBeenLastCalledWith('fifth')
       await promise5
     })
+
+    it('should execute a trailing call scheduled after a prior execution', async () => {
+      const mockFn = vi.fn(
+        (_: string) =>
+          new Promise((resolve) => setTimeout(() => resolve('result'), 500)),
+      )
+      const debouncer = new AsyncDebouncer(mockFn, {
+        wait: 1000,
+        leading: true,
+        trailing: true,
+      })
+
+      // First call - should execute immediately
+      const promise1 = debouncer.maybeExecute('first')
+      expect(mockFn).toBeCalledTimes(1)
+      expect(mockFn).toBeCalledWith('first')
+
+      // Second call enqueued during first execution
+      const promise2 = debouncer.maybeExecute('second')
+      expect(mockFn).toBeCalledTimes(1)
+
+      // Advance past first execution
+      vi.advanceTimersByTime(500)
+      await promise1
+
+      // Trigger second execution
+      vi.advanceTimersByTime(1000)
+      await promise2
+
+      // Verify trailing execution occurred
+      expect(mockFn).toBeCalledTimes(2)
+      expect(mockFn).toHaveBeenLastCalledWith('second')
+    })
   })
 
   describe('Promise Handling', () => {


### PR DESCRIPTION
clear lastArgs upon execution, not after, to avoid resetting lastArgs of upcoming queued execution after current completes

## 🎯 Changes

- AsyncDebouncer: Moves `lastArgs` reset to occur synchronously before beginning an async execution (after args are already consumed) instead of after the execution completes
- Adds a regression test for the bug (#257) which caused a lost trailing execution if an in-flight execution completes between schedule and invoke.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/pacer/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed asynchronous debouncing so trailing executions are not dropped when a leading execution is still in progress.
  - Queued calls now run after the active asynchronous operation completes when both leading and trailing execution are enabled.

- **Tests**
  - Added regression coverage for trailing execution during an in-progress asynchronous call.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->