### PR TITLE
docs: disable generated page titles

### DIFF
--- a/docs/framework/angular/reference/functions/injectAsyncBatchedCallback.md
+++ b/docs/framework/angular/reference/functions/injectAsyncBatchedCallback.md
@@ -3,6 +3,8 @@ id: injectAsyncBatchedCallback
 title: injectAsyncBatchedCallback
 ---
 
+# Function: injectAsyncBatchedCallback()
+
 ```ts
 function injectAsyncBatchedCallback<TValue>(fn, options): (item) => Promise<void>;
 ```

--- a/docs/framework/angular/reference/functions/injectAsyncBatchedCallback.md
+++ b/docs/framework/angular/reference/functions/injectAsyncBatchedCallback.md
@@ -3,8 +3,6 @@ id: injectAsyncBatchedCallback
 title: injectAsyncBatchedCallback
 ---
 
-# Function: injectAsyncBatchedCallback()
-
 ```ts
 function injectAsyncBatchedCallback<TValue>(fn, options): (item) => Promise<void>;
 ```

--- a/docs/framework/angular/reference/functions/injectAsyncBatcher.md
+++ b/docs/framework/angular/reference/functions/injectAsyncBatcher.md
@@ -3,8 +3,6 @@ id: injectAsyncBatcher
 title: injectAsyncBatcher
 ---
 
-# Function: injectAsyncBatcher()
-
 ```ts
 function injectAsyncBatcher<TValue, TSelected>(
    fn, 

--- a/docs/framework/angular/reference/functions/injectAsyncBatcher.md
+++ b/docs/framework/angular/reference/functions/injectAsyncBatcher.md
@@ -3,6 +3,8 @@ id: injectAsyncBatcher
 title: injectAsyncBatcher
 ---
 
+# Function: injectAsyncBatcher()
+
 ```ts
 function injectAsyncBatcher<TValue, TSelected>(
    fn, 

--- a/docs/framework/angular/reference/functions/injectAsyncDebouncedCallback.md
+++ b/docs/framework/angular/reference/functions/injectAsyncDebouncedCallback.md
@@ -3,8 +3,6 @@ id: injectAsyncDebouncedCallback
 title: injectAsyncDebouncedCallback
 ---
 
-# Function: injectAsyncDebouncedCallback()
-
 ```ts
 function injectAsyncDebouncedCallback<TFn>(fn, options): (...args) => Promise<Awaited<ReturnType<TFn>> | undefined>;
 ```

--- a/docs/framework/angular/reference/functions/injectAsyncDebouncedCallback.md
+++ b/docs/framework/angular/reference/functions/injectAsyncDebouncedCallback.md
@@ -3,6 +3,8 @@ id: injectAsyncDebouncedCallback
 title: injectAsyncDebouncedCallback
 ---
 
+# Function: injectAsyncDebouncedCallback()
+
 ```ts
 function injectAsyncDebouncedCallback<TFn>(fn, options): (...args) => Promise<Awaited<ReturnType<TFn>> | undefined>;
 ```

--- a/docs/framework/angular/reference/functions/injectAsyncDebouncer.md
+++ b/docs/framework/angular/reference/functions/injectAsyncDebouncer.md
@@ -3,8 +3,6 @@ id: injectAsyncDebouncer
 title: injectAsyncDebouncer
 ---
 
-# Function: injectAsyncDebouncer()
-
 ```ts
 function injectAsyncDebouncer<TFn, TSelected>(
    fn, 

--- a/docs/framework/angular/reference/functions/injectAsyncDebouncer.md
+++ b/docs/framework/angular/reference/functions/injectAsyncDebouncer.md
@@ -3,6 +3,8 @@ id: injectAsyncDebouncer
 title: injectAsyncDebouncer
 ---
 
+# Function: injectAsyncDebouncer()
+
 ```ts
 function injectAsyncDebouncer<TFn, TSelected>(
    fn, 

--- a/docs/framework/angular/reference/functions/injectAsyncQueuedSignal.md
+++ b/docs/framework/angular/reference/functions/injectAsyncQueuedSignal.md
@@ -3,8 +3,6 @@ id: injectAsyncQueuedSignal
 title: injectAsyncQueuedSignal
 ---
 
-# Function: injectAsyncQueuedSignal()
-
 ```ts
 function injectAsyncQueuedSignal<TValue, TSelected>(
    fn, 

--- a/docs/framework/angular/reference/functions/injectAsyncQueuedSignal.md
+++ b/docs/framework/angular/reference/functions/injectAsyncQueuedSignal.md
@@ -3,6 +3,8 @@ id: injectAsyncQueuedSignal
 title: injectAsyncQueuedSignal
 ---
 
+# Function: injectAsyncQueuedSignal()
+
 ```ts
 function injectAsyncQueuedSignal<TValue, TSelected>(
    fn, 

--- a/docs/framework/angular/reference/functions/injectAsyncQueuer.md
+++ b/docs/framework/angular/reference/functions/injectAsyncQueuer.md
@@ -3,6 +3,8 @@ id: injectAsyncQueuer
 title: injectAsyncQueuer
 ---
 
+# Function: injectAsyncQueuer()
+
 ```ts
 function injectAsyncQueuer<TValue, TSelected>(
    fn, 

--- a/docs/framework/angular/reference/functions/injectAsyncQueuer.md
+++ b/docs/framework/angular/reference/functions/injectAsyncQueuer.md
@@ -3,8 +3,6 @@ id: injectAsyncQueuer
 title: injectAsyncQueuer
 ---
 
-# Function: injectAsyncQueuer()
-
 ```ts
 function injectAsyncQueuer<TValue, TSelected>(
    fn, 

--- a/docs/framework/angular/reference/functions/injectAsyncRateLimitedCallback.md
+++ b/docs/framework/angular/reference/functions/injectAsyncRateLimitedCallback.md
@@ -3,6 +3,8 @@ id: injectAsyncRateLimitedCallback
 title: injectAsyncRateLimitedCallback
 ---
 
+# Function: injectAsyncRateLimitedCallback()
+
 ```ts
 function injectAsyncRateLimitedCallback<TFn>(fn, options): (...args) => Promise<Awaited<ReturnType<TFn>> | undefined>;
 ```

--- a/docs/framework/angular/reference/functions/injectAsyncRateLimitedCallback.md
+++ b/docs/framework/angular/reference/functions/injectAsyncRateLimitedCallback.md
@@ -3,8 +3,6 @@ id: injectAsyncRateLimitedCallback
 title: injectAsyncRateLimitedCallback
 ---
 
-# Function: injectAsyncRateLimitedCallback()
-
 ```ts
 function injectAsyncRateLimitedCallback<TFn>(fn, options): (...args) => Promise<Awaited<ReturnType<TFn>> | undefined>;
 ```

--- a/docs/framework/angular/reference/functions/injectAsyncRateLimiter.md
+++ b/docs/framework/angular/reference/functions/injectAsyncRateLimiter.md
@@ -3,8 +3,6 @@ id: injectAsyncRateLimiter
 title: injectAsyncRateLimiter
 ---
 
-# Function: injectAsyncRateLimiter()
-
 ```ts
 function injectAsyncRateLimiter<TFn, TSelected>(
    fn, 

--- a/docs/framework/angular/reference/functions/injectAsyncRateLimiter.md
+++ b/docs/framework/angular/reference/functions/injectAsyncRateLimiter.md
@@ -3,6 +3,8 @@ id: injectAsyncRateLimiter
 title: injectAsyncRateLimiter
 ---
 
+# Function: injectAsyncRateLimiter()
+
 ```ts
 function injectAsyncRateLimiter<TFn, TSelected>(
    fn, 

--- a/docs/framework/angular/reference/functions/injectAsyncThrottledCallback.md
+++ b/docs/framework/angular/reference/functions/injectAsyncThrottledCallback.md
@@ -3,6 +3,8 @@ id: injectAsyncThrottledCallback
 title: injectAsyncThrottledCallback
 ---
 
+# Function: injectAsyncThrottledCallback()
+
 ```ts
 function injectAsyncThrottledCallback<TFn>(fn, options): (...args) => Promise<Awaited<ReturnType<TFn>> | undefined>;
 ```

--- a/docs/framework/angular/reference/functions/injectAsyncThrottledCallback.md
+++ b/docs/framework/angular/reference/functions/injectAsyncThrottledCallback.md
@@ -3,8 +3,6 @@ id: injectAsyncThrottledCallback
 title: injectAsyncThrottledCallback
 ---
 
-# Function: injectAsyncThrottledCallback()
-
 ```ts
 function injectAsyncThrottledCallback<TFn>(fn, options): (...args) => Promise<Awaited<ReturnType<TFn>> | undefined>;
 ```

--- a/docs/framework/angular/reference/functions/injectAsyncThrottler.md
+++ b/docs/framework/angular/reference/functions/injectAsyncThrottler.md
@@ -3,6 +3,8 @@ id: injectAsyncThrottler
 title: injectAsyncThrottler
 ---
 
+# Function: injectAsyncThrottler()
+
 ```ts
 function injectAsyncThrottler<TFn, TSelected>(
    fn, 

--- a/docs/framework/angular/reference/functions/injectAsyncThrottler.md
+++ b/docs/framework/angular/reference/functions/injectAsyncThrottler.md
@@ -3,8 +3,6 @@ id: injectAsyncThrottler
 title: injectAsyncThrottler
 ---
 
-# Function: injectAsyncThrottler()
-
 ```ts
 function injectAsyncThrottler<TFn, TSelected>(
    fn, 

--- a/docs/framework/angular/reference/functions/injectBatchedCallback.md
+++ b/docs/framework/angular/reference/functions/injectBatchedCallback.md
@@ -3,8 +3,6 @@ id: injectBatchedCallback
 title: injectBatchedCallback
 ---
 
-# Function: injectBatchedCallback()
-
 ```ts
 function injectBatchedCallback<TValue>(fn, options): (item) => void;
 ```

--- a/docs/framework/angular/reference/functions/injectBatchedCallback.md
+++ b/docs/framework/angular/reference/functions/injectBatchedCallback.md
@@ -3,6 +3,8 @@ id: injectBatchedCallback
 title: injectBatchedCallback
 ---
 
+# Function: injectBatchedCallback()
+
 ```ts
 function injectBatchedCallback<TValue>(fn, options): (item) => void;
 ```

--- a/docs/framework/angular/reference/functions/injectBatcher.md
+++ b/docs/framework/angular/reference/functions/injectBatcher.md
@@ -3,6 +3,8 @@ id: injectBatcher
 title: injectBatcher
 ---
 
+# Function: injectBatcher()
+
 ```ts
 function injectBatcher<TValue, TSelected>(
    fn, 

--- a/docs/framework/angular/reference/functions/injectBatcher.md
+++ b/docs/framework/angular/reference/functions/injectBatcher.md
@@ -3,8 +3,6 @@ id: injectBatcher
 title: injectBatcher
 ---
 
-# Function: injectBatcher()
-
 ```ts
 function injectBatcher<TValue, TSelected>(
    fn, 

--- a/docs/framework/angular/reference/functions/injectDebouncedCallback.md
+++ b/docs/framework/angular/reference/functions/injectDebouncedCallback.md
@@ -3,6 +3,8 @@ id: injectDebouncedCallback
 title: injectDebouncedCallback
 ---
 
+# Function: injectDebouncedCallback()
+
 ```ts
 function injectDebouncedCallback<TFn>(fn, options): (...args) => void;
 ```

--- a/docs/framework/angular/reference/functions/injectDebouncedCallback.md
+++ b/docs/framework/angular/reference/functions/injectDebouncedCallback.md
@@ -3,8 +3,6 @@ id: injectDebouncedCallback
 title: injectDebouncedCallback
 ---
 
-# Function: injectDebouncedCallback()
-
 ```ts
 function injectDebouncedCallback<TFn>(fn, options): (...args) => void;
 ```

--- a/docs/framework/angular/reference/functions/injectDebouncedSignal.md
+++ b/docs/framework/angular/reference/functions/injectDebouncedSignal.md
@@ -3,6 +3,8 @@ id: injectDebouncedSignal
 title: injectDebouncedSignal
 ---
 
+# Function: injectDebouncedSignal()
+
 ```ts
 function injectDebouncedSignal<TValue, TSelected>(
    value, 

--- a/docs/framework/angular/reference/functions/injectDebouncedSignal.md
+++ b/docs/framework/angular/reference/functions/injectDebouncedSignal.md
@@ -3,8 +3,6 @@ id: injectDebouncedSignal
 title: injectDebouncedSignal
 ---
 
-# Function: injectDebouncedSignal()
-
 ```ts
 function injectDebouncedSignal<TValue, TSelected>(
    value, 

--- a/docs/framework/angular/reference/functions/injectDebouncedValue.md
+++ b/docs/framework/angular/reference/functions/injectDebouncedValue.md
@@ -3,6 +3,8 @@ id: injectDebouncedValue
 title: injectDebouncedValue
 ---
 
+# Function: injectDebouncedValue()
+
 ## Call Signature
 
 ```ts

--- a/docs/framework/angular/reference/functions/injectDebouncedValue.md
+++ b/docs/framework/angular/reference/functions/injectDebouncedValue.md
@@ -3,8 +3,6 @@ id: injectDebouncedValue
 title: injectDebouncedValue
 ---
 
-# Function: injectDebouncedValue()
-
 ## Call Signature
 
 ```ts

--- a/docs/framework/angular/reference/functions/injectDebouncer.md
+++ b/docs/framework/angular/reference/functions/injectDebouncer.md
@@ -3,8 +3,6 @@ id: injectDebouncer
 title: injectDebouncer
 ---
 
-# Function: injectDebouncer()
-
 ```ts
 function injectDebouncer<TFn, TSelected>(
    fn, 

--- a/docs/framework/angular/reference/functions/injectDebouncer.md
+++ b/docs/framework/angular/reference/functions/injectDebouncer.md
@@ -3,6 +3,8 @@ id: injectDebouncer
 title: injectDebouncer
 ---
 
+# Function: injectDebouncer()
+
 ```ts
 function injectDebouncer<TFn, TSelected>(
    fn, 

--- a/docs/framework/angular/reference/functions/injectQueuedSignal.md
+++ b/docs/framework/angular/reference/functions/injectQueuedSignal.md
@@ -3,8 +3,6 @@ id: injectQueuedSignal
 title: injectQueuedSignal
 ---
 
-# Function: injectQueuedSignal()
-
 ```ts
 function injectQueuedSignal<TValue, TSelected>(
    fn, 

--- a/docs/framework/angular/reference/functions/injectQueuedSignal.md
+++ b/docs/framework/angular/reference/functions/injectQueuedSignal.md
@@ -3,6 +3,8 @@ id: injectQueuedSignal
 title: injectQueuedSignal
 ---
 
+# Function: injectQueuedSignal()
+
 ```ts
 function injectQueuedSignal<TValue, TSelected>(
    fn, 

--- a/docs/framework/angular/reference/functions/injectQueuedValue.md
+++ b/docs/framework/angular/reference/functions/injectQueuedValue.md
@@ -3,8 +3,6 @@ id: injectQueuedValue
 title: injectQueuedValue
 ---
 
-# Function: injectQueuedValue()
-
 ## Call Signature
 
 ```ts

--- a/docs/framework/angular/reference/functions/injectQueuedValue.md
+++ b/docs/framework/angular/reference/functions/injectQueuedValue.md
@@ -3,6 +3,8 @@ id: injectQueuedValue
 title: injectQueuedValue
 ---
 
+# Function: injectQueuedValue()
+
 ## Call Signature
 
 ```ts

--- a/docs/framework/angular/reference/functions/injectQueuer.md
+++ b/docs/framework/angular/reference/functions/injectQueuer.md
@@ -3,6 +3,8 @@ id: injectQueuer
 title: injectQueuer
 ---
 
+# Function: injectQueuer()
+
 ```ts
 function injectQueuer<TValue, TSelected>(
    fn, 

--- a/docs/framework/angular/reference/functions/injectQueuer.md
+++ b/docs/framework/angular/reference/functions/injectQueuer.md
@@ -3,8 +3,6 @@ id: injectQueuer
 title: injectQueuer
 ---
 
-# Function: injectQueuer()
-
 ```ts
 function injectQueuer<TValue, TSelected>(
    fn, 

--- a/docs/framework/angular/reference/functions/injectRateLimitedCallback.md
+++ b/docs/framework/angular/reference/functions/injectRateLimitedCallback.md
@@ -3,8 +3,6 @@ id: injectRateLimitedCallback
 title: injectRateLimitedCallback
 ---
 
-# Function: injectRateLimitedCallback()
-
 ```ts
 function injectRateLimitedCallback<TFn>(fn, options): (...args) => boolean;
 ```

--- a/docs/framework/angular/reference/functions/injectRateLimitedCallback.md
+++ b/docs/framework/angular/reference/functions/injectRateLimitedCallback.md
@@ -3,6 +3,8 @@ id: injectRateLimitedCallback
 title: injectRateLimitedCallback
 ---
 
+# Function: injectRateLimitedCallback()
+
 ```ts
 function injectRateLimitedCallback<TFn>(fn, options): (...args) => boolean;
 ```

--- a/docs/framework/angular/reference/functions/injectRateLimitedSignal.md
+++ b/docs/framework/angular/reference/functions/injectRateLimitedSignal.md
@@ -3,6 +3,8 @@ id: injectRateLimitedSignal
 title: injectRateLimitedSignal
 ---
 
+# Function: injectRateLimitedSignal()
+
 ```ts
 function injectRateLimitedSignal<TValue, TSelected>(
    value, 

--- a/docs/framework/angular/reference/functions/injectRateLimitedSignal.md
+++ b/docs/framework/angular/reference/functions/injectRateLimitedSignal.md
@@ -3,8 +3,6 @@ id: injectRateLimitedSignal
 title: injectRateLimitedSignal
 ---
 
-# Function: injectRateLimitedSignal()
-
 ```ts
 function injectRateLimitedSignal<TValue, TSelected>(
    value, 

--- a/docs/framework/angular/reference/functions/injectRateLimitedValue.md
+++ b/docs/framework/angular/reference/functions/injectRateLimitedValue.md
@@ -3,8 +3,6 @@ id: injectRateLimitedValue
 title: injectRateLimitedValue
 ---
 
-# Function: injectRateLimitedValue()
-
 ## Call Signature
 
 ```ts

--- a/docs/framework/angular/reference/functions/injectRateLimitedValue.md
+++ b/docs/framework/angular/reference/functions/injectRateLimitedValue.md
@@ -3,6 +3,8 @@ id: injectRateLimitedValue
 title: injectRateLimitedValue
 ---
 
+# Function: injectRateLimitedValue()
+
 ## Call Signature
 
 ```ts

--- a/docs/framework/angular/reference/functions/injectRateLimiter.md
+++ b/docs/framework/angular/reference/functions/injectRateLimiter.md
@@ -3,8 +3,6 @@ id: injectRateLimiter
 title: injectRateLimiter
 ---
 
-# Function: injectRateLimiter()
-
 ```ts
 function injectRateLimiter<TFn, TSelected>(
    fn, 

--- a/docs/framework/angular/reference/functions/injectRateLimiter.md
+++ b/docs/framework/angular/reference/functions/injectRateLimiter.md
@@ -3,6 +3,8 @@ id: injectRateLimiter
 title: injectRateLimiter
 ---
 
+# Function: injectRateLimiter()
+
 ```ts
 function injectRateLimiter<TFn, TSelected>(
    fn, 

--- a/docs/framework/angular/reference/functions/injectThrottledCallback.md
+++ b/docs/framework/angular/reference/functions/injectThrottledCallback.md
@@ -3,8 +3,6 @@ id: injectThrottledCallback
 title: injectThrottledCallback
 ---
 
-# Function: injectThrottledCallback()
-
 ```ts
 function injectThrottledCallback<TFn>(fn, options): (...args) => void;
 ```

--- a/docs/framework/angular/reference/functions/injectThrottledCallback.md
+++ b/docs/framework/angular/reference/functions/injectThrottledCallback.md
@@ -3,6 +3,8 @@ id: injectThrottledCallback
 title: injectThrottledCallback
 ---
 
+# Function: injectThrottledCallback()
+
 ```ts
 function injectThrottledCallback<TFn>(fn, options): (...args) => void;
 ```

--- a/docs/framework/angular/reference/functions/injectThrottledSignal.md
+++ b/docs/framework/angular/reference/functions/injectThrottledSignal.md
@@ -3,6 +3,8 @@ id: injectThrottledSignal
 title: injectThrottledSignal
 ---
 
+# Function: injectThrottledSignal()
+
 ```ts
 function injectThrottledSignal<TValue, TSelected>(
    value, 

--- a/docs/framework/angular/reference/functions/injectThrottledSignal.md
+++ b/docs/framework/angular/reference/functions/injectThrottledSignal.md
@@ -3,8 +3,6 @@ id: injectThrottledSignal
 title: injectThrottledSignal
 ---
 
-# Function: injectThrottledSignal()
-
 ```ts
 function injectThrottledSignal<TValue, TSelected>(
    value, 

--- a/docs/framework/angular/reference/functions/injectThrottledValue.md
+++ b/docs/framework/angular/reference/functions/injectThrottledValue.md
@@ -3,8 +3,6 @@ id: injectThrottledValue
 title: injectThrottledValue
 ---
 
-# Function: injectThrottledValue()
-
 ## Call Signature
 
 ```ts

--- a/docs/framework/angular/reference/functions/injectThrottledValue.md
+++ b/docs/framework/angular/reference/functions/injectThrottledValue.md
@@ -3,6 +3,8 @@ id: injectThrottledValue
 title: injectThrottledValue
 ---
 
+# Function: injectThrottledValue()
+
 ## Call Signature
 
 ```ts

--- a/docs/framework/angular/reference/functions/injectThrottler.md
+++ b/docs/framework/angular/reference/functions/injectThrottler.md
@@ -3,8 +3,6 @@ id: injectThrottler
 title: injectThrottler
 ---
 
-# Function: injectThrottler()
-
 ```ts
 function injectThrottler<TFn, TSelected>(
    fn, 

--- a/docs/framework/angular/reference/functions/injectThrottler.md
+++ b/docs/framework/angular/reference/functions/injectThrottler.md
@@ -3,6 +3,8 @@ id: injectThrottler
 title: injectThrottler
 ---
 
+# Function: injectThrottler()
+
 ```ts
 function injectThrottler<TFn, TSelected>(
    fn, 

--- a/docs/framework/angular/reference/functions/providePacerOptions.md
+++ b/docs/framework/angular/reference/functions/providePacerOptions.md
@@ -3,8 +3,6 @@ id: providePacerOptions
 title: providePacerOptions
 ---
 
-# Function: providePacerOptions()
-
 ```ts
 function providePacerOptions(options): Provider;
 ```

--- a/docs/framework/angular/reference/functions/providePacerOptions.md
+++ b/docs/framework/angular/reference/functions/providePacerOptions.md
@@ -3,6 +3,8 @@ id: providePacerOptions
 title: providePacerOptions
 ---
 
+# Function: providePacerOptions()
+
 ```ts
 function providePacerOptions(options): Provider;
 ```

--- a/docs/framework/angular/reference/index.md
+++ b/docs/framework/angular/reference/index.md
@@ -3,6 +3,8 @@ id: "@tanstack/angular-pacer"
 title: "@tanstack/angular-pacer"
 ---
 
+# @tanstack/angular-pacer
+
 ## Interfaces
 
 - [AngularAsyncBatcher](interfaces/AngularAsyncBatcher.md)

--- a/docs/framework/angular/reference/index.md
+++ b/docs/framework/angular/reference/index.md
@@ -3,8 +3,6 @@ id: "@tanstack/angular-pacer"
 title: "@tanstack/angular-pacer"
 ---
 
-# @tanstack/angular-pacer
-
 ## Interfaces
 
 - [AngularAsyncBatcher](interfaces/AngularAsyncBatcher.md)

--- a/docs/framework/angular/reference/interfaces/AngularAsyncBatcher.md
+++ b/docs/framework/angular/reference/interfaces/AngularAsyncBatcher.md
@@ -3,8 +3,6 @@ id: AngularAsyncBatcher
 title: AngularAsyncBatcher
 ---
 
-# Interface: AngularAsyncBatcher\<TValue, TSelected\>
-
 Defined in: [angular-pacer/src/async-batcher/injectAsyncBatcher.ts:24](https://github.com/TanStack/pacer/blob/main/packages/angular-pacer/src/async-batcher/injectAsyncBatcher.ts#L24)
 
 ## Extends

--- a/docs/framework/angular/reference/interfaces/AngularAsyncBatcher.md
+++ b/docs/framework/angular/reference/interfaces/AngularAsyncBatcher.md
@@ -3,6 +3,8 @@ id: AngularAsyncBatcher
 title: AngularAsyncBatcher
 ---
 
+# Interface: AngularAsyncBatcher\<TValue, TSelected\>
+
 Defined in: [angular-pacer/src/async-batcher/injectAsyncBatcher.ts:24](https://github.com/TanStack/pacer/blob/main/packages/angular-pacer/src/async-batcher/injectAsyncBatcher.ts#L24)
 
 ## Extends

--- a/docs/framework/angular/reference/interfaces/AngularAsyncBatcherOptions.md
+++ b/docs/framework/angular/reference/interfaces/AngularAsyncBatcherOptions.md
@@ -3,6 +3,8 @@ id: AngularAsyncBatcherOptions
 title: AngularAsyncBatcherOptions
 ---
 
+# Interface: AngularAsyncBatcherOptions\<TValue, TSelected\>
+
 Defined in: [angular-pacer/src/async-batcher/injectAsyncBatcher.ts:12](https://github.com/TanStack/pacer/blob/main/packages/angular-pacer/src/async-batcher/injectAsyncBatcher.ts#L12)
 
 ## Extends

--- a/docs/framework/angular/reference/interfaces/AngularAsyncBatcherOptions.md
+++ b/docs/framework/angular/reference/interfaces/AngularAsyncBatcherOptions.md
@@ -3,8 +3,6 @@ id: AngularAsyncBatcherOptions
 title: AngularAsyncBatcherOptions
 ---
 
-# Interface: AngularAsyncBatcherOptions\<TValue, TSelected\>
-
 Defined in: [angular-pacer/src/async-batcher/injectAsyncBatcher.ts:12](https://github.com/TanStack/pacer/blob/main/packages/angular-pacer/src/async-batcher/injectAsyncBatcher.ts#L12)
 
 ## Extends

--- a/docs/framework/angular/reference/interfaces/AngularAsyncDebouncer.md
+++ b/docs/framework/angular/reference/interfaces/AngularAsyncDebouncer.md
@@ -3,8 +3,6 @@ id: AngularAsyncDebouncer
 title: AngularAsyncDebouncer
 ---
 
-# Interface: AngularAsyncDebouncer\<TFn, TSelected\>
-
 Defined in: [angular-pacer/src/async-debouncer/injectAsyncDebouncer.ts:25](https://github.com/TanStack/pacer/blob/main/packages/angular-pacer/src/async-debouncer/injectAsyncDebouncer.ts#L25)
 
 ## Extends

--- a/docs/framework/angular/reference/interfaces/AngularAsyncDebouncer.md
+++ b/docs/framework/angular/reference/interfaces/AngularAsyncDebouncer.md
@@ -3,6 +3,8 @@ id: AngularAsyncDebouncer
 title: AngularAsyncDebouncer
 ---
 
+# Interface: AngularAsyncDebouncer\<TFn, TSelected\>
+
 Defined in: [angular-pacer/src/async-debouncer/injectAsyncDebouncer.ts:25](https://github.com/TanStack/pacer/blob/main/packages/angular-pacer/src/async-debouncer/injectAsyncDebouncer.ts#L25)
 
 ## Extends

--- a/docs/framework/angular/reference/interfaces/AngularAsyncDebouncerOptions.md
+++ b/docs/framework/angular/reference/interfaces/AngularAsyncDebouncerOptions.md
@@ -3,8 +3,6 @@ id: AngularAsyncDebouncerOptions
 title: AngularAsyncDebouncerOptions
 ---
 
-# Interface: AngularAsyncDebouncerOptions\<TFn, TSelected\>
-
 Defined in: [angular-pacer/src/async-debouncer/injectAsyncDebouncer.ts:13](https://github.com/TanStack/pacer/blob/main/packages/angular-pacer/src/async-debouncer/injectAsyncDebouncer.ts#L13)
 
 ## Extends

--- a/docs/framework/angular/reference/interfaces/AngularAsyncDebouncerOptions.md
+++ b/docs/framework/angular/reference/interfaces/AngularAsyncDebouncerOptions.md
@@ -3,6 +3,8 @@ id: AngularAsyncDebouncerOptions
 title: AngularAsyncDebouncerOptions
 ---
 
+# Interface: AngularAsyncDebouncerOptions\<TFn, TSelected\>
+
 Defined in: [angular-pacer/src/async-debouncer/injectAsyncDebouncer.ts:13](https://github.com/TanStack/pacer/blob/main/packages/angular-pacer/src/async-debouncer/injectAsyncDebouncer.ts#L13)
 
 ## Extends

--- a/docs/framework/angular/reference/interfaces/AngularAsyncQueuer.md
+++ b/docs/framework/angular/reference/interfaces/AngularAsyncQueuer.md
@@ -3,8 +3,6 @@ id: AngularAsyncQueuer
 title: AngularAsyncQueuer
 ---
 
-# Interface: AngularAsyncQueuer\<TValue, TSelected\>
-
 Defined in: [angular-pacer/src/async-queuer/injectAsyncQueuer.ts:24](https://github.com/TanStack/pacer/blob/main/packages/angular-pacer/src/async-queuer/injectAsyncQueuer.ts#L24)
 
 ## Extends

--- a/docs/framework/angular/reference/interfaces/AngularAsyncQueuer.md
+++ b/docs/framework/angular/reference/interfaces/AngularAsyncQueuer.md
@@ -3,6 +3,8 @@ id: AngularAsyncQueuer
 title: AngularAsyncQueuer
 ---
 
+# Interface: AngularAsyncQueuer\<TValue, TSelected\>
+
 Defined in: [angular-pacer/src/async-queuer/injectAsyncQueuer.ts:24](https://github.com/TanStack/pacer/blob/main/packages/angular-pacer/src/async-queuer/injectAsyncQueuer.ts#L24)
 
 ## Extends

--- a/docs/framework/angular/reference/interfaces/AngularAsyncQueuerOptions.md
+++ b/docs/framework/angular/reference/interfaces/AngularAsyncQueuerOptions.md
@@ -3,8 +3,6 @@ id: AngularAsyncQueuerOptions
 title: AngularAsyncQueuerOptions
 ---
 
-# Interface: AngularAsyncQueuerOptions\<TValue, TSelected\>
-
 Defined in: [angular-pacer/src/async-queuer/injectAsyncQueuer.ts:12](https://github.com/TanStack/pacer/blob/main/packages/angular-pacer/src/async-queuer/injectAsyncQueuer.ts#L12)
 
 ## Extends

--- a/docs/framework/angular/reference/interfaces/AngularAsyncQueuerOptions.md
+++ b/docs/framework/angular/reference/interfaces/AngularAsyncQueuerOptions.md
@@ -3,6 +3,8 @@ id: AngularAsyncQueuerOptions
 title: AngularAsyncQueuerOptions
 ---
 
+# Interface: AngularAsyncQueuerOptions\<TValue, TSelected\>
+
 Defined in: [angular-pacer/src/async-queuer/injectAsyncQueuer.ts:12](https://github.com/TanStack/pacer/blob/main/packages/angular-pacer/src/async-queuer/injectAsyncQueuer.ts#L12)
 
 ## Extends

--- a/docs/framework/angular/reference/interfaces/AngularAsyncRateLimiter.md
+++ b/docs/framework/angular/reference/interfaces/AngularAsyncRateLimiter.md
@@ -3,8 +3,6 @@ id: AngularAsyncRateLimiter
 title: AngularAsyncRateLimiter
 ---
 
-# Interface: AngularAsyncRateLimiter\<TFn, TSelected\>
-
 Defined in: [angular-pacer/src/async-rate-limiter/injectAsyncRateLimiter.ts:24](https://github.com/TanStack/pacer/blob/main/packages/angular-pacer/src/async-rate-limiter/injectAsyncRateLimiter.ts#L24)
 
 ## Extends

--- a/docs/framework/angular/reference/interfaces/AngularAsyncRateLimiter.md
+++ b/docs/framework/angular/reference/interfaces/AngularAsyncRateLimiter.md
@@ -3,6 +3,8 @@ id: AngularAsyncRateLimiter
 title: AngularAsyncRateLimiter
 ---
 
+# Interface: AngularAsyncRateLimiter\<TFn, TSelected\>
+
 Defined in: [angular-pacer/src/async-rate-limiter/injectAsyncRateLimiter.ts:24](https://github.com/TanStack/pacer/blob/main/packages/angular-pacer/src/async-rate-limiter/injectAsyncRateLimiter.ts#L24)
 
 ## Extends

--- a/docs/framework/angular/reference/interfaces/AngularAsyncRateLimiterOptions.md
+++ b/docs/framework/angular/reference/interfaces/AngularAsyncRateLimiterOptions.md
@@ -3,6 +3,8 @@ id: AngularAsyncRateLimiterOptions
 title: AngularAsyncRateLimiterOptions
 ---
 
+# Interface: AngularAsyncRateLimiterOptions\<TFn, TSelected\>
+
 Defined in: [angular-pacer/src/async-rate-limiter/injectAsyncRateLimiter.ts:13](https://github.com/TanStack/pacer/blob/main/packages/angular-pacer/src/async-rate-limiter/injectAsyncRateLimiter.ts#L13)
 
 ## Extends

--- a/docs/framework/angular/reference/interfaces/AngularAsyncRateLimiterOptions.md
+++ b/docs/framework/angular/reference/interfaces/AngularAsyncRateLimiterOptions.md
@@ -3,8 +3,6 @@ id: AngularAsyncRateLimiterOptions
 title: AngularAsyncRateLimiterOptions
 ---
 
-# Interface: AngularAsyncRateLimiterOptions\<TFn, TSelected\>
-
 Defined in: [angular-pacer/src/async-rate-limiter/injectAsyncRateLimiter.ts:13](https://github.com/TanStack/pacer/blob/main/packages/angular-pacer/src/async-rate-limiter/injectAsyncRateLimiter.ts#L13)
 
 ## Extends

--- a/docs/framework/angular/reference/interfaces/AngularAsyncThrottler.md
+++ b/docs/framework/angular/reference/interfaces/AngularAsyncThrottler.md
@@ -3,6 +3,8 @@ id: AngularAsyncThrottler
 title: AngularAsyncThrottler
 ---
 
+# Interface: AngularAsyncThrottler\<TFn, TSelected\>
+
 Defined in: [angular-pacer/src/async-throttler/injectAsyncThrottler.ts:25](https://github.com/TanStack/pacer/blob/main/packages/angular-pacer/src/async-throttler/injectAsyncThrottler.ts#L25)
 
 ## Extends

--- a/docs/framework/angular/reference/interfaces/AngularAsyncThrottler.md
+++ b/docs/framework/angular/reference/interfaces/AngularAsyncThrottler.md
@@ -3,8 +3,6 @@ id: AngularAsyncThrottler
 title: AngularAsyncThrottler
 ---
 
-# Interface: AngularAsyncThrottler\<TFn, TSelected\>
-
 Defined in: [angular-pacer/src/async-throttler/injectAsyncThrottler.ts:25](https://github.com/TanStack/pacer/blob/main/packages/angular-pacer/src/async-throttler/injectAsyncThrottler.ts#L25)
 
 ## Extends

--- a/docs/framework/angular/reference/interfaces/AngularAsyncThrottlerOptions.md
+++ b/docs/framework/angular/reference/interfaces/AngularAsyncThrottlerOptions.md
@@ -3,6 +3,8 @@ id: AngularAsyncThrottlerOptions
 title: AngularAsyncThrottlerOptions
 ---
 
+# Interface: AngularAsyncThrottlerOptions\<TFn, TSelected\>
+
 Defined in: [angular-pacer/src/async-throttler/injectAsyncThrottler.ts:13](https://github.com/TanStack/pacer/blob/main/packages/angular-pacer/src/async-throttler/injectAsyncThrottler.ts#L13)
 
 ## Extends

--- a/docs/framework/angular/reference/interfaces/AngularAsyncThrottlerOptions.md
+++ b/docs/framework/angular/reference/interfaces/AngularAsyncThrottlerOptions.md
@@ -3,8 +3,6 @@ id: AngularAsyncThrottlerOptions
 title: AngularAsyncThrottlerOptions
 ---
 
-# Interface: AngularAsyncThrottlerOptions\<TFn, TSelected\>
-
 Defined in: [angular-pacer/src/async-throttler/injectAsyncThrottler.ts:13](https://github.com/TanStack/pacer/blob/main/packages/angular-pacer/src/async-throttler/injectAsyncThrottler.ts#L13)
 
 ## Extends

--- a/docs/framework/angular/reference/interfaces/AngularBatcher.md
+++ b/docs/framework/angular/reference/interfaces/AngularBatcher.md
@@ -3,8 +3,6 @@ id: AngularBatcher
 title: AngularBatcher
 ---
 
-# Interface: AngularBatcher\<TValue, TSelected\>
-
 Defined in: [angular-pacer/src/batcher/injectBatcher.ts:20](https://github.com/TanStack/pacer/blob/main/packages/angular-pacer/src/batcher/injectBatcher.ts#L20)
 
 ## Extends

--- a/docs/framework/angular/reference/interfaces/AngularBatcher.md
+++ b/docs/framework/angular/reference/interfaces/AngularBatcher.md
@@ -3,6 +3,8 @@ id: AngularBatcher
 title: AngularBatcher
 ---
 
+# Interface: AngularBatcher\<TValue, TSelected\>
+
 Defined in: [angular-pacer/src/batcher/injectBatcher.ts:20](https://github.com/TanStack/pacer/blob/main/packages/angular-pacer/src/batcher/injectBatcher.ts#L20)
 
 ## Extends

--- a/docs/framework/angular/reference/interfaces/AngularBatcherOptions.md
+++ b/docs/framework/angular/reference/interfaces/AngularBatcherOptions.md
@@ -3,8 +3,6 @@ id: AngularBatcherOptions
 title: AngularBatcherOptions
 ---
 
-# Interface: AngularBatcherOptions\<TValue, TSelected\>
-
 Defined in: [angular-pacer/src/batcher/injectBatcher.ts:9](https://github.com/TanStack/pacer/blob/main/packages/angular-pacer/src/batcher/injectBatcher.ts#L9)
 
 ## Extends

--- a/docs/framework/angular/reference/interfaces/AngularBatcherOptions.md
+++ b/docs/framework/angular/reference/interfaces/AngularBatcherOptions.md
@@ -3,6 +3,8 @@ id: AngularBatcherOptions
 title: AngularBatcherOptions
 ---
 
+# Interface: AngularBatcherOptions\<TValue, TSelected\>
+
 Defined in: [angular-pacer/src/batcher/injectBatcher.ts:9](https://github.com/TanStack/pacer/blob/main/packages/angular-pacer/src/batcher/injectBatcher.ts#L9)
 
 ## Extends

--- a/docs/framework/angular/reference/interfaces/AngularDebouncer.md
+++ b/docs/framework/angular/reference/interfaces/AngularDebouncer.md
@@ -3,6 +3,8 @@ id: AngularDebouncer
 title: AngularDebouncer
 ---
 
+# Interface: AngularDebouncer\<TFn, TSelected\>
+
 Defined in: [angular-pacer/src/debouncer/injectDebouncer.ts:24](https://github.com/TanStack/pacer/blob/main/packages/angular-pacer/src/debouncer/injectDebouncer.ts#L24)
 
 ## Extends

--- a/docs/framework/angular/reference/interfaces/AngularDebouncer.md
+++ b/docs/framework/angular/reference/interfaces/AngularDebouncer.md
@@ -3,8 +3,6 @@ id: AngularDebouncer
 title: AngularDebouncer
 ---
 
-# Interface: AngularDebouncer\<TFn, TSelected\>
-
 Defined in: [angular-pacer/src/debouncer/injectDebouncer.ts:24](https://github.com/TanStack/pacer/blob/main/packages/angular-pacer/src/debouncer/injectDebouncer.ts#L24)
 
 ## Extends

--- a/docs/framework/angular/reference/interfaces/AngularDebouncerOptions.md
+++ b/docs/framework/angular/reference/interfaces/AngularDebouncerOptions.md
@@ -3,8 +3,6 @@ id: AngularDebouncerOptions
 title: AngularDebouncerOptions
 ---
 
-# Interface: AngularDebouncerOptions\<TFn, TSelected\>
-
 Defined in: [angular-pacer/src/debouncer/injectDebouncer.ts:13](https://github.com/TanStack/pacer/blob/main/packages/angular-pacer/src/debouncer/injectDebouncer.ts#L13)
 
 ## Extends

--- a/docs/framework/angular/reference/interfaces/AngularDebouncerOptions.md
+++ b/docs/framework/angular/reference/interfaces/AngularDebouncerOptions.md
@@ -3,6 +3,8 @@ id: AngularDebouncerOptions
 title: AngularDebouncerOptions
 ---
 
+# Interface: AngularDebouncerOptions\<TFn, TSelected\>
+
 Defined in: [angular-pacer/src/debouncer/injectDebouncer.ts:13](https://github.com/TanStack/pacer/blob/main/packages/angular-pacer/src/debouncer/injectDebouncer.ts#L13)
 
 ## Extends

--- a/docs/framework/angular/reference/interfaces/AngularQueuer.md
+++ b/docs/framework/angular/reference/interfaces/AngularQueuer.md
@@ -3,8 +3,6 @@ id: AngularQueuer
 title: AngularQueuer
 ---
 
-# Interface: AngularQueuer\<TValue, TSelected\>
-
 Defined in: [angular-pacer/src/queuer/injectQueuer.ts:20](https://github.com/TanStack/pacer/blob/main/packages/angular-pacer/src/queuer/injectQueuer.ts#L20)
 
 ## Extends

--- a/docs/framework/angular/reference/interfaces/AngularQueuer.md
+++ b/docs/framework/angular/reference/interfaces/AngularQueuer.md
@@ -3,6 +3,8 @@ id: AngularQueuer
 title: AngularQueuer
 ---
 
+# Interface: AngularQueuer\<TValue, TSelected\>
+
 Defined in: [angular-pacer/src/queuer/injectQueuer.ts:20](https://github.com/TanStack/pacer/blob/main/packages/angular-pacer/src/queuer/injectQueuer.ts#L20)
 
 ## Extends

--- a/docs/framework/angular/reference/interfaces/AngularQueuerOptions.md
+++ b/docs/framework/angular/reference/interfaces/AngularQueuerOptions.md
@@ -3,8 +3,6 @@ id: AngularQueuerOptions
 title: AngularQueuerOptions
 ---
 
-# Interface: AngularQueuerOptions\<TValue, TSelected\>
-
 Defined in: [angular-pacer/src/queuer/injectQueuer.ts:9](https://github.com/TanStack/pacer/blob/main/packages/angular-pacer/src/queuer/injectQueuer.ts#L9)
 
 ## Extends

--- a/docs/framework/angular/reference/interfaces/AngularQueuerOptions.md
+++ b/docs/framework/angular/reference/interfaces/AngularQueuerOptions.md
@@ -3,6 +3,8 @@ id: AngularQueuerOptions
 title: AngularQueuerOptions
 ---
 
+# Interface: AngularQueuerOptions\<TValue, TSelected\>
+
 Defined in: [angular-pacer/src/queuer/injectQueuer.ts:9](https://github.com/TanStack/pacer/blob/main/packages/angular-pacer/src/queuer/injectQueuer.ts#L9)
 
 ## Extends

--- a/docs/framework/angular/reference/interfaces/AngularRateLimiter.md
+++ b/docs/framework/angular/reference/interfaces/AngularRateLimiter.md
@@ -3,8 +3,6 @@ id: AngularRateLimiter
 title: AngularRateLimiter
 ---
 
-# Interface: AngularRateLimiter\<TFn, TSelected\>
-
 Defined in: [angular-pacer/src/rate-limiter/injectRateLimiter.ts:23](https://github.com/TanStack/pacer/blob/main/packages/angular-pacer/src/rate-limiter/injectRateLimiter.ts#L23)
 
 ## Extends

--- a/docs/framework/angular/reference/interfaces/AngularRateLimiter.md
+++ b/docs/framework/angular/reference/interfaces/AngularRateLimiter.md
@@ -3,6 +3,8 @@ id: AngularRateLimiter
 title: AngularRateLimiter
 ---
 
+# Interface: AngularRateLimiter\<TFn, TSelected\>
+
 Defined in: [angular-pacer/src/rate-limiter/injectRateLimiter.ts:23](https://github.com/TanStack/pacer/blob/main/packages/angular-pacer/src/rate-limiter/injectRateLimiter.ts#L23)
 
 ## Extends

--- a/docs/framework/angular/reference/interfaces/AngularRateLimiterOptions.md
+++ b/docs/framework/angular/reference/interfaces/AngularRateLimiterOptions.md
@@ -3,8 +3,6 @@ id: AngularRateLimiterOptions
 title: AngularRateLimiterOptions
 ---
 
-# Interface: AngularRateLimiterOptions\<TFn, TSelected\>
-
 Defined in: [angular-pacer/src/rate-limiter/injectRateLimiter.ts:13](https://github.com/TanStack/pacer/blob/main/packages/angular-pacer/src/rate-limiter/injectRateLimiter.ts#L13)
 
 ## Extends

--- a/docs/framework/angular/reference/interfaces/AngularRateLimiterOptions.md
+++ b/docs/framework/angular/reference/interfaces/AngularRateLimiterOptions.md
@@ -3,6 +3,8 @@ id: AngularRateLimiterOptions
 title: AngularRateLimiterOptions
 ---
 
+# Interface: AngularRateLimiterOptions\<TFn, TSelected\>
+
 Defined in: [angular-pacer/src/rate-limiter/injectRateLimiter.ts:13](https://github.com/TanStack/pacer/blob/main/packages/angular-pacer/src/rate-limiter/injectRateLimiter.ts#L13)
 
 ## Extends

--- a/docs/framework/angular/reference/interfaces/AngularThrottler.md
+++ b/docs/framework/angular/reference/interfaces/AngularThrottler.md
@@ -3,6 +3,8 @@ id: AngularThrottler
 title: AngularThrottler
 ---
 
+# Interface: AngularThrottler\<TFn, TSelected\>
+
 Defined in: [angular-pacer/src/throttler/injectThrottler.ts:24](https://github.com/TanStack/pacer/blob/main/packages/angular-pacer/src/throttler/injectThrottler.ts#L24)
 
 ## Extends

--- a/docs/framework/angular/reference/interfaces/AngularThrottler.md
+++ b/docs/framework/angular/reference/interfaces/AngularThrottler.md
@@ -3,8 +3,6 @@ id: AngularThrottler
 title: AngularThrottler
 ---
 
-# Interface: AngularThrottler\<TFn, TSelected\>
-
 Defined in: [angular-pacer/src/throttler/injectThrottler.ts:24](https://github.com/TanStack/pacer/blob/main/packages/angular-pacer/src/throttler/injectThrottler.ts#L24)
 
 ## Extends

--- a/docs/framework/angular/reference/interfaces/AngularThrottlerOptions.md
+++ b/docs/framework/angular/reference/interfaces/AngularThrottlerOptions.md
@@ -3,8 +3,6 @@ id: AngularThrottlerOptions
 title: AngularThrottlerOptions
 ---
 
-# Interface: AngularThrottlerOptions\<TFn, TSelected\>
-
 Defined in: [angular-pacer/src/throttler/injectThrottler.ts:13](https://github.com/TanStack/pacer/blob/main/packages/angular-pacer/src/throttler/injectThrottler.ts#L13)
 
 ## Extends

--- a/docs/framework/angular/reference/interfaces/AngularThrottlerOptions.md
+++ b/docs/framework/angular/reference/interfaces/AngularThrottlerOptions.md
@@ -3,6 +3,8 @@ id: AngularThrottlerOptions
 title: AngularThrottlerOptions
 ---
 
+# Interface: AngularThrottlerOptions\<TFn, TSelected\>
+
 Defined in: [angular-pacer/src/throttler/injectThrottler.ts:13](https://github.com/TanStack/pacer/blob/main/packages/angular-pacer/src/throttler/injectThrottler.ts#L13)
 
 ## Extends

--- a/docs/framework/angular/reference/interfaces/AsyncQueuedSignal.md
+++ b/docs/framework/angular/reference/interfaces/AsyncQueuedSignal.md
@@ -3,6 +3,8 @@ id: AsyncQueuedSignal
 title: AsyncQueuedSignal
 ---
 
+# Interface: AsyncQueuedSignal()\<TValue, TSelected\>
+
 Defined in: [angular-pacer/src/async-queuer/injectAsyncQueuedSignal.ts:9](https://github.com/TanStack/pacer/blob/main/packages/angular-pacer/src/async-queuer/injectAsyncQueuedSignal.ts#L9)
 
 ## Type Parameters

--- a/docs/framework/angular/reference/interfaces/AsyncQueuedSignal.md
+++ b/docs/framework/angular/reference/interfaces/AsyncQueuedSignal.md
@@ -3,8 +3,6 @@ id: AsyncQueuedSignal
 title: AsyncQueuedSignal
 ---
 
-# Interface: AsyncQueuedSignal()\<TValue, TSelected\>
-
 Defined in: [angular-pacer/src/async-queuer/injectAsyncQueuedSignal.ts:9](https://github.com/TanStack/pacer/blob/main/packages/angular-pacer/src/async-queuer/injectAsyncQueuedSignal.ts#L9)
 
 ## Type Parameters

--- a/docs/framework/angular/reference/interfaces/DebouncedSignal.md
+++ b/docs/framework/angular/reference/interfaces/DebouncedSignal.md
@@ -3,6 +3,8 @@ id: DebouncedSignal
 title: DebouncedSignal
 ---
 
+# Interface: DebouncedSignal()\<TValue, TSelected\>
+
 Defined in: [angular-pacer/src/debouncer/injectDebouncedSignal.ts:11](https://github.com/TanStack/pacer/blob/main/packages/angular-pacer/src/debouncer/injectDebouncedSignal.ts#L11)
 
 ## Type Parameters

--- a/docs/framework/angular/reference/interfaces/DebouncedSignal.md
+++ b/docs/framework/angular/reference/interfaces/DebouncedSignal.md
@@ -3,8 +3,6 @@ id: DebouncedSignal
 title: DebouncedSignal
 ---
 
-# Interface: DebouncedSignal()\<TValue, TSelected\>
-
 Defined in: [angular-pacer/src/debouncer/injectDebouncedSignal.ts:11](https://github.com/TanStack/pacer/blob/main/packages/angular-pacer/src/debouncer/injectDebouncedSignal.ts#L11)
 
 ## Type Parameters

--- a/docs/framework/angular/reference/interfaces/QueuedSignal.md
+++ b/docs/framework/angular/reference/interfaces/QueuedSignal.md
@@ -3,8 +3,6 @@ id: QueuedSignal
 title: QueuedSignal
 ---
 
-# Interface: QueuedSignal()\<TValue, TSelected\>
-
 Defined in: [angular-pacer/src/queuer/injectQueuedSignal.ts:6](https://github.com/TanStack/pacer/blob/main/packages/angular-pacer/src/queuer/injectQueuedSignal.ts#L6)
 
 ## Type Parameters

--- a/docs/framework/angular/reference/interfaces/QueuedSignal.md
+++ b/docs/framework/angular/reference/interfaces/QueuedSignal.md
@@ -3,6 +3,8 @@ id: QueuedSignal
 title: QueuedSignal
 ---
 
+# Interface: QueuedSignal()\<TValue, TSelected\>
+
 Defined in: [angular-pacer/src/queuer/injectQueuedSignal.ts:6](https://github.com/TanStack/pacer/blob/main/packages/angular-pacer/src/queuer/injectQueuedSignal.ts#L6)
 
 ## Type Parameters

--- a/docs/framework/angular/reference/interfaces/RateLimitedSignal.md
+++ b/docs/framework/angular/reference/interfaces/RateLimitedSignal.md
@@ -3,6 +3,8 @@ id: RateLimitedSignal
 title: RateLimitedSignal
 ---
 
+# Interface: RateLimitedSignal()\<TValue, TSelected\>
+
 Defined in: [angular-pacer/src/rate-limiter/injectRateLimitedSignal.ts:11](https://github.com/TanStack/pacer/blob/main/packages/angular-pacer/src/rate-limiter/injectRateLimitedSignal.ts#L11)
 
 ## Type Parameters

--- a/docs/framework/angular/reference/interfaces/RateLimitedSignal.md
+++ b/docs/framework/angular/reference/interfaces/RateLimitedSignal.md
@@ -3,8 +3,6 @@ id: RateLimitedSignal
 title: RateLimitedSignal
 ---
 
-# Interface: RateLimitedSignal()\<TValue, TSelected\>
-
 Defined in: [angular-pacer/src/rate-limiter/injectRateLimitedSignal.ts:11](https://github.com/TanStack/pacer/blob/main/packages/angular-pacer/src/rate-limiter/injectRateLimitedSignal.ts#L11)
 
 ## Type Parameters

--- a/docs/framework/angular/reference/interfaces/ThrottledSignal.md
+++ b/docs/framework/angular/reference/interfaces/ThrottledSignal.md
@@ -3,8 +3,6 @@ id: ThrottledSignal
 title: ThrottledSignal
 ---
 
-# Interface: ThrottledSignal()\<TValue, TSelected\>
-
 Defined in: [angular-pacer/src/throttler/injectThrottledSignal.ts:11](https://github.com/TanStack/pacer/blob/main/packages/angular-pacer/src/throttler/injectThrottledSignal.ts#L11)
 
 ## Type Parameters

--- a/docs/framework/angular/reference/interfaces/ThrottledSignal.md
+++ b/docs/framework/angular/reference/interfaces/ThrottledSignal.md
@@ -3,6 +3,8 @@ id: ThrottledSignal
 title: ThrottledSignal
 ---
 
+# Interface: ThrottledSignal()\<TValue, TSelected\>
+
 Defined in: [angular-pacer/src/throttler/injectThrottledSignal.ts:11](https://github.com/TanStack/pacer/blob/main/packages/angular-pacer/src/throttler/injectThrottledSignal.ts#L11)
 
 ## Type Parameters

--- a/docs/framework/preact/reference/functions/PacerProvider.md
+++ b/docs/framework/preact/reference/functions/PacerProvider.md
@@ -3,8 +3,6 @@ id: PacerProvider
 title: PacerProvider
 ---
 
-# Function: PacerProvider()
-
 ```ts
 function PacerProvider(__namedParameters): Element;
 ```

--- a/docs/framework/preact/reference/functions/PacerProvider.md
+++ b/docs/framework/preact/reference/functions/PacerProvider.md
@@ -3,6 +3,8 @@ id: PacerProvider
 title: PacerProvider
 ---
 
+# Function: PacerProvider()
+
 ```ts
 function PacerProvider(__namedParameters): Element;
 ```

--- a/docs/framework/preact/reference/functions/useAsyncBatchedCallback.md
+++ b/docs/framework/preact/reference/functions/useAsyncBatchedCallback.md
@@ -3,8 +3,6 @@ id: useAsyncBatchedCallback
 title: useAsyncBatchedCallback
 ---
 
-# Function: useAsyncBatchedCallback()
-
 ```ts
 function useAsyncBatchedCallback<TValue>(fn, options): (item) => Promise<void>;
 ```

--- a/docs/framework/preact/reference/functions/useAsyncBatchedCallback.md
+++ b/docs/framework/preact/reference/functions/useAsyncBatchedCallback.md
@@ -3,6 +3,8 @@ id: useAsyncBatchedCallback
 title: useAsyncBatchedCallback
 ---
 
+# Function: useAsyncBatchedCallback()
+
 ```ts
 function useAsyncBatchedCallback<TValue>(fn, options): (item) => Promise<void>;
 ```

--- a/docs/framework/preact/reference/functions/useAsyncBatcher.md
+++ b/docs/framework/preact/reference/functions/useAsyncBatcher.md
@@ -3,8 +3,6 @@ id: useAsyncBatcher
 title: useAsyncBatcher
 ---
 
-# Function: useAsyncBatcher()
-
 ```ts
 function useAsyncBatcher<TValue, TSelected>(
    fn, 

--- a/docs/framework/preact/reference/functions/useAsyncBatcher.md
+++ b/docs/framework/preact/reference/functions/useAsyncBatcher.md
@@ -3,6 +3,8 @@ id: useAsyncBatcher
 title: useAsyncBatcher
 ---
 
+# Function: useAsyncBatcher()
+
 ```ts
 function useAsyncBatcher<TValue, TSelected>(
    fn, 

--- a/docs/framework/preact/reference/functions/useAsyncDebouncedCallback.md
+++ b/docs/framework/preact/reference/functions/useAsyncDebouncedCallback.md
@@ -3,6 +3,8 @@ id: useAsyncDebouncedCallback
 title: useAsyncDebouncedCallback
 ---
 
+# Function: useAsyncDebouncedCallback()
+
 ```ts
 function useAsyncDebouncedCallback<TFn>(fn, options): (...args) => Promise<Awaited<ReturnType<TFn>> | undefined>;
 ```

--- a/docs/framework/preact/reference/functions/useAsyncDebouncedCallback.md
+++ b/docs/framework/preact/reference/functions/useAsyncDebouncedCallback.md
@@ -3,8 +3,6 @@ id: useAsyncDebouncedCallback
 title: useAsyncDebouncedCallback
 ---
 
-# Function: useAsyncDebouncedCallback()
-
 ```ts
 function useAsyncDebouncedCallback<TFn>(fn, options): (...args) => Promise<Awaited<ReturnType<TFn>> | undefined>;
 ```

--- a/docs/framework/preact/reference/functions/useAsyncDebouncer.md
+++ b/docs/framework/preact/reference/functions/useAsyncDebouncer.md
@@ -3,8 +3,6 @@ id: useAsyncDebouncer
 title: useAsyncDebouncer
 ---
 
-# Function: useAsyncDebouncer()
-
 ```ts
 function useAsyncDebouncer<TFn, TSelected>(
    fn, 

--- a/docs/framework/preact/reference/functions/useAsyncDebouncer.md
+++ b/docs/framework/preact/reference/functions/useAsyncDebouncer.md
@@ -3,6 +3,8 @@ id: useAsyncDebouncer
 title: useAsyncDebouncer
 ---
 
+# Function: useAsyncDebouncer()
+
 ```ts
 function useAsyncDebouncer<TFn, TSelected>(
    fn, 

--- a/docs/framework/preact/reference/functions/useAsyncQueuedState.md
+++ b/docs/framework/preact/reference/functions/useAsyncQueuedState.md
@@ -3,8 +3,6 @@ id: useAsyncQueuedState
 title: useAsyncQueuedState
 ---
 
-# Function: useAsyncQueuedState()
-
 ```ts
 function useAsyncQueuedState<TValue, TSelected>(
    fn, 

--- a/docs/framework/preact/reference/functions/useAsyncQueuedState.md
+++ b/docs/framework/preact/reference/functions/useAsyncQueuedState.md
@@ -3,6 +3,8 @@ id: useAsyncQueuedState
 title: useAsyncQueuedState
 ---
 
+# Function: useAsyncQueuedState()
+
 ```ts
 function useAsyncQueuedState<TValue, TSelected>(
    fn, 

--- a/docs/framework/preact/reference/functions/useAsyncQueuer.md
+++ b/docs/framework/preact/reference/functions/useAsyncQueuer.md
@@ -3,6 +3,8 @@ id: useAsyncQueuer
 title: useAsyncQueuer
 ---
 
+# Function: useAsyncQueuer()
+
 ```ts
 function useAsyncQueuer<TValue, TSelected>(
    fn, 

--- a/docs/framework/preact/reference/functions/useAsyncQueuer.md
+++ b/docs/framework/preact/reference/functions/useAsyncQueuer.md
@@ -3,8 +3,6 @@ id: useAsyncQueuer
 title: useAsyncQueuer
 ---
 
-# Function: useAsyncQueuer()
-
 ```ts
 function useAsyncQueuer<TValue, TSelected>(
    fn, 

--- a/docs/framework/preact/reference/functions/useAsyncRateLimitedCallback.md
+++ b/docs/framework/preact/reference/functions/useAsyncRateLimitedCallback.md
@@ -3,8 +3,6 @@ id: useAsyncRateLimitedCallback
 title: useAsyncRateLimitedCallback
 ---
 
-# Function: useAsyncRateLimitedCallback()
-
 ```ts
 function useAsyncRateLimitedCallback<TFn>(fn, options): (...args) => Promise<Awaited<ReturnType<TFn>> | undefined>;
 ```

--- a/docs/framework/preact/reference/functions/useAsyncRateLimitedCallback.md
+++ b/docs/framework/preact/reference/functions/useAsyncRateLimitedCallback.md
@@ -3,6 +3,8 @@ id: useAsyncRateLimitedCallback
 title: useAsyncRateLimitedCallback
 ---
 
+# Function: useAsyncRateLimitedCallback()
+
 ```ts
 function useAsyncRateLimitedCallback<TFn>(fn, options): (...args) => Promise<Awaited<ReturnType<TFn>> | undefined>;
 ```

--- a/docs/framework/preact/reference/functions/useAsyncRateLimiter.md
+++ b/docs/framework/preact/reference/functions/useAsyncRateLimiter.md
@@ -3,8 +3,6 @@ id: useAsyncRateLimiter
 title: useAsyncRateLimiter
 ---
 
-# Function: useAsyncRateLimiter()
-
 ```ts
 function useAsyncRateLimiter<TFn, TSelected>(
    fn, 

--- a/docs/framework/preact/reference/functions/useAsyncRateLimiter.md
+++ b/docs/framework/preact/reference/functions/useAsyncRateLimiter.md
@@ -3,6 +3,8 @@ id: useAsyncRateLimiter
 title: useAsyncRateLimiter
 ---
 
+# Function: useAsyncRateLimiter()
+
 ```ts
 function useAsyncRateLimiter<TFn, TSelected>(
    fn, 

--- a/docs/framework/preact/reference/functions/useAsyncThrottledCallback.md
+++ b/docs/framework/preact/reference/functions/useAsyncThrottledCallback.md
@@ -3,8 +3,6 @@ id: useAsyncThrottledCallback
 title: useAsyncThrottledCallback
 ---
 
-# Function: useAsyncThrottledCallback()
-
 ```ts
 function useAsyncThrottledCallback<TFn>(fn, options): (...args) => Promise<Awaited<ReturnType<TFn>> | undefined>;
 ```

--- a/docs/framework/preact/reference/functions/useAsyncThrottledCallback.md
+++ b/docs/framework/preact/reference/functions/useAsyncThrottledCallback.md
@@ -3,6 +3,8 @@ id: useAsyncThrottledCallback
 title: useAsyncThrottledCallback
 ---
 
+# Function: useAsyncThrottledCallback()
+
 ```ts
 function useAsyncThrottledCallback<TFn>(fn, options): (...args) => Promise<Awaited<ReturnType<TFn>> | undefined>;
 ```

--- a/docs/framework/preact/reference/functions/useAsyncThrottler.md
+++ b/docs/framework/preact/reference/functions/useAsyncThrottler.md
@@ -3,6 +3,8 @@ id: useAsyncThrottler
 title: useAsyncThrottler
 ---
 
+# Function: useAsyncThrottler()
+
 ```ts
 function useAsyncThrottler<TFn, TSelected>(
    fn, 

--- a/docs/framework/preact/reference/functions/useAsyncThrottler.md
+++ b/docs/framework/preact/reference/functions/useAsyncThrottler.md
@@ -3,8 +3,6 @@ id: useAsyncThrottler
 title: useAsyncThrottler
 ---
 
-# Function: useAsyncThrottler()
-
 ```ts
 function useAsyncThrottler<TFn, TSelected>(
    fn, 

--- a/docs/framework/preact/reference/functions/useBatchedCallback.md
+++ b/docs/framework/preact/reference/functions/useBatchedCallback.md
@@ -3,6 +3,8 @@ id: useBatchedCallback
 title: useBatchedCallback
 ---
 
+# Function: useBatchedCallback()
+
 ```ts
 function useBatchedCallback<TValue>(fn, options): (item) => void;
 ```

--- a/docs/framework/preact/reference/functions/useBatchedCallback.md
+++ b/docs/framework/preact/reference/functions/useBatchedCallback.md
@@ -3,8 +3,6 @@ id: useBatchedCallback
 title: useBatchedCallback
 ---
 
-# Function: useBatchedCallback()
-
 ```ts
 function useBatchedCallback<TValue>(fn, options): (item) => void;
 ```

--- a/docs/framework/preact/reference/functions/useBatcher.md
+++ b/docs/framework/preact/reference/functions/useBatcher.md
@@ -3,6 +3,8 @@ id: useBatcher
 title: useBatcher
 ---
 
+# Function: useBatcher()
+
 ```ts
 function useBatcher<TValue, TSelected>(
    fn, 

--- a/docs/framework/preact/reference/functions/useBatcher.md
+++ b/docs/framework/preact/reference/functions/useBatcher.md
@@ -3,8 +3,6 @@ id: useBatcher
 title: useBatcher
 ---
 
-# Function: useBatcher()
-
 ```ts
 function useBatcher<TValue, TSelected>(
    fn, 

--- a/docs/framework/preact/reference/functions/useDebouncedCallback.md
+++ b/docs/framework/preact/reference/functions/useDebouncedCallback.md
@@ -3,8 +3,6 @@ id: useDebouncedCallback
 title: useDebouncedCallback
 ---
 
-# Function: useDebouncedCallback()
-
 ```ts
 function useDebouncedCallback<TFn>(fn, options): (...args) => void;
 ```

--- a/docs/framework/preact/reference/functions/useDebouncedCallback.md
+++ b/docs/framework/preact/reference/functions/useDebouncedCallback.md
@@ -3,6 +3,8 @@ id: useDebouncedCallback
 title: useDebouncedCallback
 ---
 
+# Function: useDebouncedCallback()
+
 ```ts
 function useDebouncedCallback<TFn>(fn, options): (...args) => void;
 ```

--- a/docs/framework/preact/reference/functions/useDebouncedState.md
+++ b/docs/framework/preact/reference/functions/useDebouncedState.md
@@ -3,8 +3,6 @@ id: useDebouncedState
 title: useDebouncedState
 ---
 
-# Function: useDebouncedState()
-
 ```ts
 function useDebouncedState<TValue, TSelected>(
    value, 

--- a/docs/framework/preact/reference/functions/useDebouncedState.md
+++ b/docs/framework/preact/reference/functions/useDebouncedState.md
@@ -3,6 +3,8 @@ id: useDebouncedState
 title: useDebouncedState
 ---
 
+# Function: useDebouncedState()
+
 ```ts
 function useDebouncedState<TValue, TSelected>(
    value, 

--- a/docs/framework/preact/reference/functions/useDebouncedValue.md
+++ b/docs/framework/preact/reference/functions/useDebouncedValue.md
@@ -3,8 +3,6 @@ id: useDebouncedValue
 title: useDebouncedValue
 ---
 
-# Function: useDebouncedValue()
-
 ```ts
 function useDebouncedValue<TValue, TSelected>(
    value, 

--- a/docs/framework/preact/reference/functions/useDebouncedValue.md
+++ b/docs/framework/preact/reference/functions/useDebouncedValue.md
@@ -3,6 +3,8 @@ id: useDebouncedValue
 title: useDebouncedValue
 ---
 
+# Function: useDebouncedValue()
+
 ```ts
 function useDebouncedValue<TValue, TSelected>(
    value, 

--- a/docs/framework/preact/reference/functions/useDebouncer.md
+++ b/docs/framework/preact/reference/functions/useDebouncer.md
@@ -3,8 +3,6 @@ id: useDebouncer
 title: useDebouncer
 ---
 
-# Function: useDebouncer()
-
 ```ts
 function useDebouncer<TFn, TSelected>(
    fn, 

--- a/docs/framework/preact/reference/functions/useDebouncer.md
+++ b/docs/framework/preact/reference/functions/useDebouncer.md
@@ -3,6 +3,8 @@ id: useDebouncer
 title: useDebouncer
 ---
 
+# Function: useDebouncer()
+
 ```ts
 function useDebouncer<TFn, TSelected>(
    fn, 

--- a/docs/framework/preact/reference/functions/useDefaultPacerOptions.md
+++ b/docs/framework/preact/reference/functions/useDefaultPacerOptions.md
@@ -3,6 +3,8 @@ id: useDefaultPacerOptions
 title: useDefaultPacerOptions
 ---
 
+# Function: useDefaultPacerOptions()
+
 ```ts
 function useDefaultPacerOptions(): PacerProviderOptions;
 ```

--- a/docs/framework/preact/reference/functions/useDefaultPacerOptions.md
+++ b/docs/framework/preact/reference/functions/useDefaultPacerOptions.md
@@ -3,8 +3,6 @@ id: useDefaultPacerOptions
 title: useDefaultPacerOptions
 ---
 
-# Function: useDefaultPacerOptions()
-
 ```ts
 function useDefaultPacerOptions(): PacerProviderOptions;
 ```

--- a/docs/framework/preact/reference/functions/usePacerContext.md
+++ b/docs/framework/preact/reference/functions/usePacerContext.md
@@ -3,8 +3,6 @@ id: usePacerContext
 title: usePacerContext
 ---
 
-# Function: usePacerContext()
-
 ```ts
 function usePacerContext(): PacerContextValue | null;
 ```

--- a/docs/framework/preact/reference/functions/usePacerContext.md
+++ b/docs/framework/preact/reference/functions/usePacerContext.md
@@ -3,6 +3,8 @@ id: usePacerContext
 title: usePacerContext
 ---
 
+# Function: usePacerContext()
+
 ```ts
 function usePacerContext(): PacerContextValue | null;
 ```

--- a/docs/framework/preact/reference/functions/useQueuedState.md
+++ b/docs/framework/preact/reference/functions/useQueuedState.md
@@ -3,8 +3,6 @@ id: useQueuedState
 title: useQueuedState
 ---
 
-# Function: useQueuedState()
-
 ```ts
 function useQueuedState<TValue, TSelected>(
    fn, 

--- a/docs/framework/preact/reference/functions/useQueuedState.md
+++ b/docs/framework/preact/reference/functions/useQueuedState.md
@@ -3,6 +3,8 @@ id: useQueuedState
 title: useQueuedState
 ---
 
+# Function: useQueuedState()
+
 ```ts
 function useQueuedState<TValue, TSelected>(
    fn, 

--- a/docs/framework/preact/reference/functions/useQueuedValue.md
+++ b/docs/framework/preact/reference/functions/useQueuedValue.md
@@ -3,6 +3,8 @@ id: useQueuedValue
 title: useQueuedValue
 ---
 
+# Function: useQueuedValue()
+
 ```ts
 function useQueuedValue<TValue, TSelected>(
    initialValue, 

--- a/docs/framework/preact/reference/functions/useQueuedValue.md
+++ b/docs/framework/preact/reference/functions/useQueuedValue.md
@@ -3,8 +3,6 @@ id: useQueuedValue
 title: useQueuedValue
 ---
 
-# Function: useQueuedValue()
-
 ```ts
 function useQueuedValue<TValue, TSelected>(
    initialValue, 

--- a/docs/framework/preact/reference/functions/useQueuer.md
+++ b/docs/framework/preact/reference/functions/useQueuer.md
@@ -3,6 +3,8 @@ id: useQueuer
 title: useQueuer
 ---
 
+# Function: useQueuer()
+
 ```ts
 function useQueuer<TValue, TSelected>(
    fn, 

--- a/docs/framework/preact/reference/functions/useQueuer.md
+++ b/docs/framework/preact/reference/functions/useQueuer.md
@@ -3,8 +3,6 @@ id: useQueuer
 title: useQueuer
 ---
 
-# Function: useQueuer()
-
 ```ts
 function useQueuer<TValue, TSelected>(
    fn, 

--- a/docs/framework/preact/reference/functions/useRateLimitedCallback.md
+++ b/docs/framework/preact/reference/functions/useRateLimitedCallback.md
@@ -3,8 +3,6 @@ id: useRateLimitedCallback
 title: useRateLimitedCallback
 ---
 
-# Function: useRateLimitedCallback()
-
 ```ts
 function useRateLimitedCallback<TFn>(fn, options): (...args) => boolean;
 ```

--- a/docs/framework/preact/reference/functions/useRateLimitedCallback.md
+++ b/docs/framework/preact/reference/functions/useRateLimitedCallback.md
@@ -3,6 +3,8 @@ id: useRateLimitedCallback
 title: useRateLimitedCallback
 ---
 
+# Function: useRateLimitedCallback()
+
 ```ts
 function useRateLimitedCallback<TFn>(fn, options): (...args) => boolean;
 ```

--- a/docs/framework/preact/reference/functions/useRateLimitedState.md
+++ b/docs/framework/preact/reference/functions/useRateLimitedState.md
@@ -3,8 +3,6 @@ id: useRateLimitedState
 title: useRateLimitedState
 ---
 
-# Function: useRateLimitedState()
-
 ```ts
 function useRateLimitedState<TValue, TSelected>(
    value, 

--- a/docs/framework/preact/reference/functions/useRateLimitedState.md
+++ b/docs/framework/preact/reference/functions/useRateLimitedState.md
@@ -3,6 +3,8 @@ id: useRateLimitedState
 title: useRateLimitedState
 ---
 
+# Function: useRateLimitedState()
+
 ```ts
 function useRateLimitedState<TValue, TSelected>(
    value, 

--- a/docs/framework/preact/reference/functions/useRateLimitedValue.md
+++ b/docs/framework/preact/reference/functions/useRateLimitedValue.md
@@ -3,6 +3,8 @@ id: useRateLimitedValue
 title: useRateLimitedValue
 ---
 
+# Function: useRateLimitedValue()
+
 ```ts
 function useRateLimitedValue<TValue, TSelected>(
    value, 

--- a/docs/framework/preact/reference/functions/useRateLimitedValue.md
+++ b/docs/framework/preact/reference/functions/useRateLimitedValue.md
@@ -3,8 +3,6 @@ id: useRateLimitedValue
 title: useRateLimitedValue
 ---
 
-# Function: useRateLimitedValue()
-
 ```ts
 function useRateLimitedValue<TValue, TSelected>(
    value, 

--- a/docs/framework/preact/reference/functions/useRateLimiter.md
+++ b/docs/framework/preact/reference/functions/useRateLimiter.md
@@ -3,6 +3,8 @@ id: useRateLimiter
 title: useRateLimiter
 ---
 
+# Function: useRateLimiter()
+
 ```ts
 function useRateLimiter<TFn, TSelected>(
    fn, 

--- a/docs/framework/preact/reference/functions/useRateLimiter.md
+++ b/docs/framework/preact/reference/functions/useRateLimiter.md
@@ -3,8 +3,6 @@ id: useRateLimiter
 title: useRateLimiter
 ---
 
-# Function: useRateLimiter()
-
 ```ts
 function useRateLimiter<TFn, TSelected>(
    fn, 

--- a/docs/framework/preact/reference/functions/useThrottledCallback.md
+++ b/docs/framework/preact/reference/functions/useThrottledCallback.md
@@ -3,6 +3,8 @@ id: useThrottledCallback
 title: useThrottledCallback
 ---
 
+# Function: useThrottledCallback()
+
 ```ts
 function useThrottledCallback<TFn>(fn, options): (...args) => void;
 ```

--- a/docs/framework/preact/reference/functions/useThrottledCallback.md
+++ b/docs/framework/preact/reference/functions/useThrottledCallback.md
@@ -3,8 +3,6 @@ id: useThrottledCallback
 title: useThrottledCallback
 ---
 
-# Function: useThrottledCallback()
-
 ```ts
 function useThrottledCallback<TFn>(fn, options): (...args) => void;
 ```

--- a/docs/framework/preact/reference/functions/useThrottledState.md
+++ b/docs/framework/preact/reference/functions/useThrottledState.md
@@ -3,6 +3,8 @@ id: useThrottledState
 title: useThrottledState
 ---
 
+# Function: useThrottledState()
+
 ```ts
 function useThrottledState<TValue, TSelected>(
    value, 

--- a/docs/framework/preact/reference/functions/useThrottledState.md
+++ b/docs/framework/preact/reference/functions/useThrottledState.md
@@ -3,8 +3,6 @@ id: useThrottledState
 title: useThrottledState
 ---
 
-# Function: useThrottledState()
-
 ```ts
 function useThrottledState<TValue, TSelected>(
    value, 

--- a/docs/framework/preact/reference/functions/useThrottledValue.md
+++ b/docs/framework/preact/reference/functions/useThrottledValue.md
@@ -3,6 +3,8 @@ id: useThrottledValue
 title: useThrottledValue
 ---
 
+# Function: useThrottledValue()
+
 ```ts
 function useThrottledValue<TValue, TSelected>(
    value, 

--- a/docs/framework/preact/reference/functions/useThrottledValue.md
+++ b/docs/framework/preact/reference/functions/useThrottledValue.md
@@ -3,8 +3,6 @@ id: useThrottledValue
 title: useThrottledValue
 ---
 
-# Function: useThrottledValue()
-
 ```ts
 function useThrottledValue<TValue, TSelected>(
    value, 

--- a/docs/framework/preact/reference/functions/useThrottler.md
+++ b/docs/framework/preact/reference/functions/useThrottler.md
@@ -3,8 +3,6 @@ id: useThrottler
 title: useThrottler
 ---
 
-# Function: useThrottler()
-
 ```ts
 function useThrottler<TFn, TSelected>(
    fn, 

--- a/docs/framework/preact/reference/functions/useThrottler.md
+++ b/docs/framework/preact/reference/functions/useThrottler.md
@@ -3,6 +3,8 @@ id: useThrottler
 title: useThrottler
 ---
 
+# Function: useThrottler()
+
 ```ts
 function useThrottler<TFn, TSelected>(
    fn, 

--- a/docs/framework/preact/reference/index.md
+++ b/docs/framework/preact/reference/index.md
@@ -3,6 +3,8 @@ id: "@tanstack/preact-pacer"
 title: "@tanstack/preact-pacer"
 ---
 
+# @tanstack/preact-pacer
+
 ## Interfaces
 
 - [PacerProviderOptions](interfaces/PacerProviderOptions.md)

--- a/docs/framework/preact/reference/index.md
+++ b/docs/framework/preact/reference/index.md
@@ -3,8 +3,6 @@ id: "@tanstack/preact-pacer"
 title: "@tanstack/preact-pacer"
 ---
 
-# @tanstack/preact-pacer
-
 ## Interfaces
 
 - [PacerProviderOptions](interfaces/PacerProviderOptions.md)

--- a/docs/framework/preact/reference/interfaces/PacerProviderOptions.md
+++ b/docs/framework/preact/reference/interfaces/PacerProviderOptions.md
@@ -3,8 +3,6 @@ id: PacerProviderOptions
 title: PacerProviderOptions
 ---
 
-# Interface: PacerProviderOptions
-
 Defined in: [preact-pacer/src/provider/PacerProvider.tsx:19](https://github.com/TanStack/pacer/blob/main/packages/preact-pacer/src/provider/PacerProvider.tsx#L19)
 
 ## Properties

--- a/docs/framework/preact/reference/interfaces/PacerProviderOptions.md
+++ b/docs/framework/preact/reference/interfaces/PacerProviderOptions.md
@@ -3,6 +3,8 @@ id: PacerProviderOptions
 title: PacerProviderOptions
 ---
 
+# Interface: PacerProviderOptions
+
 Defined in: [preact-pacer/src/provider/PacerProvider.tsx:19](https://github.com/TanStack/pacer/blob/main/packages/preact-pacer/src/provider/PacerProvider.tsx#L19)
 
 ## Properties

--- a/docs/framework/preact/reference/interfaces/PacerProviderProps.md
+++ b/docs/framework/preact/reference/interfaces/PacerProviderProps.md
@@ -3,8 +3,6 @@ id: PacerProviderProps
 title: PacerProviderProps
 ---
 
-# Interface: PacerProviderProps
-
 Defined in: [preact-pacer/src/provider/PacerProvider.tsx:38](https://github.com/TanStack/pacer/blob/main/packages/preact-pacer/src/provider/PacerProvider.tsx#L38)
 
 ## Properties

--- a/docs/framework/preact/reference/interfaces/PacerProviderProps.md
+++ b/docs/framework/preact/reference/interfaces/PacerProviderProps.md
@@ -3,6 +3,8 @@ id: PacerProviderProps
 title: PacerProviderProps
 ---
 
+# Interface: PacerProviderProps
+
 Defined in: [preact-pacer/src/provider/PacerProvider.tsx:38](https://github.com/TanStack/pacer/blob/main/packages/preact-pacer/src/provider/PacerProvider.tsx#L38)
 
 ## Properties

--- a/docs/framework/preact/reference/interfaces/PreactAsyncBatcher.md
+++ b/docs/framework/preact/reference/interfaces/PreactAsyncBatcher.md
@@ -3,6 +3,8 @@ id: PreactAsyncBatcher
 title: PreactAsyncBatcher
 ---
 
+# Interface: PreactAsyncBatcher\<TValue, TSelected\>
+
 Defined in: [preact-pacer/src/async-batcher/useAsyncBatcher.ts:23](https://github.com/TanStack/pacer/blob/main/packages/preact-pacer/src/async-batcher/useAsyncBatcher.ts#L23)
 
 ## Extends

--- a/docs/framework/preact/reference/interfaces/PreactAsyncBatcher.md
+++ b/docs/framework/preact/reference/interfaces/PreactAsyncBatcher.md
@@ -3,8 +3,6 @@ id: PreactAsyncBatcher
 title: PreactAsyncBatcher
 ---
 
-# Interface: PreactAsyncBatcher\<TValue, TSelected\>
-
 Defined in: [preact-pacer/src/async-batcher/useAsyncBatcher.ts:23](https://github.com/TanStack/pacer/blob/main/packages/preact-pacer/src/async-batcher/useAsyncBatcher.ts#L23)
 
 ## Extends

--- a/docs/framework/preact/reference/interfaces/PreactAsyncBatcherOptions.md
+++ b/docs/framework/preact/reference/interfaces/PreactAsyncBatcherOptions.md
@@ -3,6 +3,8 @@ id: PreactAsyncBatcherOptions
 title: PreactAsyncBatcherOptions
 ---
 
+# Interface: PreactAsyncBatcherOptions\<TValue, TSelected\>
+
 Defined in: [preact-pacer/src/async-batcher/useAsyncBatcher.ts:12](https://github.com/TanStack/pacer/blob/main/packages/preact-pacer/src/async-batcher/useAsyncBatcher.ts#L12)
 
 ## Extends

--- a/docs/framework/preact/reference/interfaces/PreactAsyncBatcherOptions.md
+++ b/docs/framework/preact/reference/interfaces/PreactAsyncBatcherOptions.md
@@ -3,8 +3,6 @@ id: PreactAsyncBatcherOptions
 title: PreactAsyncBatcherOptions
 ---
 
-# Interface: PreactAsyncBatcherOptions\<TValue, TSelected\>
-
 Defined in: [preact-pacer/src/async-batcher/useAsyncBatcher.ts:12](https://github.com/TanStack/pacer/blob/main/packages/preact-pacer/src/async-batcher/useAsyncBatcher.ts#L12)
 
 ## Extends

--- a/docs/framework/preact/reference/interfaces/PreactAsyncDebouncer.md
+++ b/docs/framework/preact/reference/interfaces/PreactAsyncDebouncer.md
@@ -3,6 +3,8 @@ id: PreactAsyncDebouncer
 title: PreactAsyncDebouncer
 ---
 
+# Interface: PreactAsyncDebouncer\<TFn, TSelected\>
+
 Defined in: [preact-pacer/src/async-debouncer/useAsyncDebouncer.ts:24](https://github.com/TanStack/pacer/blob/main/packages/preact-pacer/src/async-debouncer/useAsyncDebouncer.ts#L24)
 
 ## Extends

--- a/docs/framework/preact/reference/interfaces/PreactAsyncDebouncer.md
+++ b/docs/framework/preact/reference/interfaces/PreactAsyncDebouncer.md
@@ -3,8 +3,6 @@ id: PreactAsyncDebouncer
 title: PreactAsyncDebouncer
 ---
 
-# Interface: PreactAsyncDebouncer\<TFn, TSelected\>
-
 Defined in: [preact-pacer/src/async-debouncer/useAsyncDebouncer.ts:24](https://github.com/TanStack/pacer/blob/main/packages/preact-pacer/src/async-debouncer/useAsyncDebouncer.ts#L24)
 
 ## Extends

--- a/docs/framework/preact/reference/interfaces/PreactAsyncDebouncerOptions.md
+++ b/docs/framework/preact/reference/interfaces/PreactAsyncDebouncerOptions.md
@@ -3,8 +3,6 @@ id: PreactAsyncDebouncerOptions
 title: PreactAsyncDebouncerOptions
 ---
 
-# Interface: PreactAsyncDebouncerOptions\<TFn, TSelected\>
-
 Defined in: [preact-pacer/src/async-debouncer/useAsyncDebouncer.ts:13](https://github.com/TanStack/pacer/blob/main/packages/preact-pacer/src/async-debouncer/useAsyncDebouncer.ts#L13)
 
 ## Extends

--- a/docs/framework/preact/reference/interfaces/PreactAsyncDebouncerOptions.md
+++ b/docs/framework/preact/reference/interfaces/PreactAsyncDebouncerOptions.md
@@ -3,6 +3,8 @@ id: PreactAsyncDebouncerOptions
 title: PreactAsyncDebouncerOptions
 ---
 
+# Interface: PreactAsyncDebouncerOptions\<TFn, TSelected\>
+
 Defined in: [preact-pacer/src/async-debouncer/useAsyncDebouncer.ts:13](https://github.com/TanStack/pacer/blob/main/packages/preact-pacer/src/async-debouncer/useAsyncDebouncer.ts#L13)
 
 ## Extends

--- a/docs/framework/preact/reference/interfaces/PreactAsyncQueuer.md
+++ b/docs/framework/preact/reference/interfaces/PreactAsyncQueuer.md
@@ -3,6 +3,8 @@ id: PreactAsyncQueuer
 title: PreactAsyncQueuer
 ---
 
+# Interface: PreactAsyncQueuer\<TValue, TSelected\>
+
 Defined in: [preact-pacer/src/async-queuer/useAsyncQueuer.ts:23](https://github.com/TanStack/pacer/blob/main/packages/preact-pacer/src/async-queuer/useAsyncQueuer.ts#L23)
 
 ## Extends

--- a/docs/framework/preact/reference/interfaces/PreactAsyncQueuer.md
+++ b/docs/framework/preact/reference/interfaces/PreactAsyncQueuer.md
@@ -3,8 +3,6 @@ id: PreactAsyncQueuer
 title: PreactAsyncQueuer
 ---
 
-# Interface: PreactAsyncQueuer\<TValue, TSelected\>
-
 Defined in: [preact-pacer/src/async-queuer/useAsyncQueuer.ts:23](https://github.com/TanStack/pacer/blob/main/packages/preact-pacer/src/async-queuer/useAsyncQueuer.ts#L23)
 
 ## Extends

--- a/docs/framework/preact/reference/interfaces/PreactAsyncQueuerOptions.md
+++ b/docs/framework/preact/reference/interfaces/PreactAsyncQueuerOptions.md
@@ -3,8 +3,6 @@ id: PreactAsyncQueuerOptions
 title: PreactAsyncQueuerOptions
 ---
 
-# Interface: PreactAsyncQueuerOptions\<TValue, TSelected\>
-
 Defined in: [preact-pacer/src/async-queuer/useAsyncQueuer.ts:12](https://github.com/TanStack/pacer/blob/main/packages/preact-pacer/src/async-queuer/useAsyncQueuer.ts#L12)
 
 ## Extends

--- a/docs/framework/preact/reference/interfaces/PreactAsyncQueuerOptions.md
+++ b/docs/framework/preact/reference/interfaces/PreactAsyncQueuerOptions.md
@@ -3,6 +3,8 @@ id: PreactAsyncQueuerOptions
 title: PreactAsyncQueuerOptions
 ---
 
+# Interface: PreactAsyncQueuerOptions\<TValue, TSelected\>
+
 Defined in: [preact-pacer/src/async-queuer/useAsyncQueuer.ts:12](https://github.com/TanStack/pacer/blob/main/packages/preact-pacer/src/async-queuer/useAsyncQueuer.ts#L12)
 
 ## Extends

--- a/docs/framework/preact/reference/interfaces/PreactAsyncRateLimiter.md
+++ b/docs/framework/preact/reference/interfaces/PreactAsyncRateLimiter.md
@@ -3,8 +3,6 @@ id: PreactAsyncRateLimiter
 title: PreactAsyncRateLimiter
 ---
 
-# Interface: PreactAsyncRateLimiter\<TFn, TSelected\>
-
 Defined in: [preact-pacer/src/async-rate-limiter/useAsyncRateLimiter.ts:24](https://github.com/TanStack/pacer/blob/main/packages/preact-pacer/src/async-rate-limiter/useAsyncRateLimiter.ts#L24)
 
 ## Extends

--- a/docs/framework/preact/reference/interfaces/PreactAsyncRateLimiter.md
+++ b/docs/framework/preact/reference/interfaces/PreactAsyncRateLimiter.md
@@ -3,6 +3,8 @@ id: PreactAsyncRateLimiter
 title: PreactAsyncRateLimiter
 ---
 
+# Interface: PreactAsyncRateLimiter\<TFn, TSelected\>
+
 Defined in: [preact-pacer/src/async-rate-limiter/useAsyncRateLimiter.ts:24](https://github.com/TanStack/pacer/blob/main/packages/preact-pacer/src/async-rate-limiter/useAsyncRateLimiter.ts#L24)
 
 ## Extends

--- a/docs/framework/preact/reference/interfaces/PreactAsyncRateLimiterOptions.md
+++ b/docs/framework/preact/reference/interfaces/PreactAsyncRateLimiterOptions.md
@@ -3,6 +3,8 @@ id: PreactAsyncRateLimiterOptions
 title: PreactAsyncRateLimiterOptions
 ---
 
+# Interface: PreactAsyncRateLimiterOptions\<TFn, TSelected\>
+
 Defined in: [preact-pacer/src/async-rate-limiter/useAsyncRateLimiter.ts:13](https://github.com/TanStack/pacer/blob/main/packages/preact-pacer/src/async-rate-limiter/useAsyncRateLimiter.ts#L13)
 
 ## Extends

--- a/docs/framework/preact/reference/interfaces/PreactAsyncRateLimiterOptions.md
+++ b/docs/framework/preact/reference/interfaces/PreactAsyncRateLimiterOptions.md
@@ -3,8 +3,6 @@ id: PreactAsyncRateLimiterOptions
 title: PreactAsyncRateLimiterOptions
 ---
 
-# Interface: PreactAsyncRateLimiterOptions\<TFn, TSelected\>
-
 Defined in: [preact-pacer/src/async-rate-limiter/useAsyncRateLimiter.ts:13](https://github.com/TanStack/pacer/blob/main/packages/preact-pacer/src/async-rate-limiter/useAsyncRateLimiter.ts#L13)
 
 ## Extends

--- a/docs/framework/preact/reference/interfaces/PreactAsyncThrottler.md
+++ b/docs/framework/preact/reference/interfaces/PreactAsyncThrottler.md
@@ -3,6 +3,8 @@ id: PreactAsyncThrottler
 title: PreactAsyncThrottler
 ---
 
+# Interface: PreactAsyncThrottler\<TFn, TSelected\>
+
 Defined in: [preact-pacer/src/async-throttler/useAsyncThrottler.ts:24](https://github.com/TanStack/pacer/blob/main/packages/preact-pacer/src/async-throttler/useAsyncThrottler.ts#L24)
 
 ## Extends

--- a/docs/framework/preact/reference/interfaces/PreactAsyncThrottler.md
+++ b/docs/framework/preact/reference/interfaces/PreactAsyncThrottler.md
@@ -3,8 +3,6 @@ id: PreactAsyncThrottler
 title: PreactAsyncThrottler
 ---
 
-# Interface: PreactAsyncThrottler\<TFn, TSelected\>
-
 Defined in: [preact-pacer/src/async-throttler/useAsyncThrottler.ts:24](https://github.com/TanStack/pacer/blob/main/packages/preact-pacer/src/async-throttler/useAsyncThrottler.ts#L24)
 
 ## Extends

--- a/docs/framework/preact/reference/interfaces/PreactAsyncThrottlerOptions.md
+++ b/docs/framework/preact/reference/interfaces/PreactAsyncThrottlerOptions.md
@@ -3,8 +3,6 @@ id: PreactAsyncThrottlerOptions
 title: PreactAsyncThrottlerOptions
 ---
 
-# Interface: PreactAsyncThrottlerOptions\<TFn, TSelected\>
-
 Defined in: [preact-pacer/src/async-throttler/useAsyncThrottler.ts:13](https://github.com/TanStack/pacer/blob/main/packages/preact-pacer/src/async-throttler/useAsyncThrottler.ts#L13)
 
 ## Extends

--- a/docs/framework/preact/reference/interfaces/PreactAsyncThrottlerOptions.md
+++ b/docs/framework/preact/reference/interfaces/PreactAsyncThrottlerOptions.md
@@ -3,6 +3,8 @@ id: PreactAsyncThrottlerOptions
 title: PreactAsyncThrottlerOptions
 ---
 
+# Interface: PreactAsyncThrottlerOptions\<TFn, TSelected\>
+
 Defined in: [preact-pacer/src/async-throttler/useAsyncThrottler.ts:13](https://github.com/TanStack/pacer/blob/main/packages/preact-pacer/src/async-throttler/useAsyncThrottler.ts#L13)
 
 ## Extends

--- a/docs/framework/preact/reference/interfaces/PreactBatcher.md
+++ b/docs/framework/preact/reference/interfaces/PreactBatcher.md
@@ -3,8 +3,6 @@ id: PreactBatcher
 title: PreactBatcher
 ---
 
-# Interface: PreactBatcher\<TValue, TSelected\>
-
 Defined in: [preact-pacer/src/batcher/useBatcher.ts:20](https://github.com/TanStack/pacer/blob/main/packages/preact-pacer/src/batcher/useBatcher.ts#L20)
 
 ## Extends

--- a/docs/framework/preact/reference/interfaces/PreactBatcher.md
+++ b/docs/framework/preact/reference/interfaces/PreactBatcher.md
@@ -3,6 +3,8 @@ id: PreactBatcher
 title: PreactBatcher
 ---
 
+# Interface: PreactBatcher\<TValue, TSelected\>
+
 Defined in: [preact-pacer/src/batcher/useBatcher.ts:20](https://github.com/TanStack/pacer/blob/main/packages/preact-pacer/src/batcher/useBatcher.ts#L20)
 
 ## Extends

--- a/docs/framework/preact/reference/interfaces/PreactBatcherOptions.md
+++ b/docs/framework/preact/reference/interfaces/PreactBatcherOptions.md
@@ -3,6 +3,8 @@ id: PreactBatcherOptions
 title: PreactBatcherOptions
 ---
 
+# Interface: PreactBatcherOptions\<TValue, TSelected\>
+
 Defined in: [preact-pacer/src/batcher/useBatcher.ts:9](https://github.com/TanStack/pacer/blob/main/packages/preact-pacer/src/batcher/useBatcher.ts#L9)
 
 ## Extends

--- a/docs/framework/preact/reference/interfaces/PreactBatcherOptions.md
+++ b/docs/framework/preact/reference/interfaces/PreactBatcherOptions.md
@@ -3,8 +3,6 @@ id: PreactBatcherOptions
 title: PreactBatcherOptions
 ---
 
-# Interface: PreactBatcherOptions\<TValue, TSelected\>
-
 Defined in: [preact-pacer/src/batcher/useBatcher.ts:9](https://github.com/TanStack/pacer/blob/main/packages/preact-pacer/src/batcher/useBatcher.ts#L9)
 
 ## Extends

--- a/docs/framework/preact/reference/interfaces/PreactDebouncer.md
+++ b/docs/framework/preact/reference/interfaces/PreactDebouncer.md
@@ -3,6 +3,8 @@ id: PreactDebouncer
 title: PreactDebouncer
 ---
 
+# Interface: PreactDebouncer\<TFn, TSelected\>
+
 Defined in: [preact-pacer/src/debouncer/useDebouncer.ts:24](https://github.com/TanStack/pacer/blob/main/packages/preact-pacer/src/debouncer/useDebouncer.ts#L24)
 
 ## Extends

--- a/docs/framework/preact/reference/interfaces/PreactDebouncer.md
+++ b/docs/framework/preact/reference/interfaces/PreactDebouncer.md
@@ -3,8 +3,6 @@ id: PreactDebouncer
 title: PreactDebouncer
 ---
 
-# Interface: PreactDebouncer\<TFn, TSelected\>
-
 Defined in: [preact-pacer/src/debouncer/useDebouncer.ts:24](https://github.com/TanStack/pacer/blob/main/packages/preact-pacer/src/debouncer/useDebouncer.ts#L24)
 
 ## Extends

--- a/docs/framework/preact/reference/interfaces/PreactDebouncerOptions.md
+++ b/docs/framework/preact/reference/interfaces/PreactDebouncerOptions.md
@@ -3,6 +3,8 @@ id: PreactDebouncerOptions
 title: PreactDebouncerOptions
 ---
 
+# Interface: PreactDebouncerOptions\<TFn, TSelected\>
+
 Defined in: [preact-pacer/src/debouncer/useDebouncer.ts:13](https://github.com/TanStack/pacer/blob/main/packages/preact-pacer/src/debouncer/useDebouncer.ts#L13)
 
 ## Extends

--- a/docs/framework/preact/reference/interfaces/PreactDebouncerOptions.md
+++ b/docs/framework/preact/reference/interfaces/PreactDebouncerOptions.md
@@ -3,8 +3,6 @@ id: PreactDebouncerOptions
 title: PreactDebouncerOptions
 ---
 
-# Interface: PreactDebouncerOptions\<TFn, TSelected\>
-
 Defined in: [preact-pacer/src/debouncer/useDebouncer.ts:13](https://github.com/TanStack/pacer/blob/main/packages/preact-pacer/src/debouncer/useDebouncer.ts#L13)
 
 ## Extends

--- a/docs/framework/preact/reference/interfaces/PreactQueuer.md
+++ b/docs/framework/preact/reference/interfaces/PreactQueuer.md
@@ -3,6 +3,8 @@ id: PreactQueuer
 title: PreactQueuer
 ---
 
+# Interface: PreactQueuer\<TValue, TSelected\>
+
 Defined in: [preact-pacer/src/queuer/useQueuer.ts:20](https://github.com/TanStack/pacer/blob/main/packages/preact-pacer/src/queuer/useQueuer.ts#L20)
 
 ## Extends

--- a/docs/framework/preact/reference/interfaces/PreactQueuer.md
+++ b/docs/framework/preact/reference/interfaces/PreactQueuer.md
@@ -3,8 +3,6 @@ id: PreactQueuer
 title: PreactQueuer
 ---
 
-# Interface: PreactQueuer\<TValue, TSelected\>
-
 Defined in: [preact-pacer/src/queuer/useQueuer.ts:20](https://github.com/TanStack/pacer/blob/main/packages/preact-pacer/src/queuer/useQueuer.ts#L20)
 
 ## Extends

--- a/docs/framework/preact/reference/interfaces/PreactQueuerOptions.md
+++ b/docs/framework/preact/reference/interfaces/PreactQueuerOptions.md
@@ -3,8 +3,6 @@ id: PreactQueuerOptions
 title: PreactQueuerOptions
 ---
 
-# Interface: PreactQueuerOptions\<TValue, TSelected\>
-
 Defined in: [preact-pacer/src/queuer/useQueuer.ts:9](https://github.com/TanStack/pacer/blob/main/packages/preact-pacer/src/queuer/useQueuer.ts#L9)
 
 ## Extends

--- a/docs/framework/preact/reference/interfaces/PreactQueuerOptions.md
+++ b/docs/framework/preact/reference/interfaces/PreactQueuerOptions.md
@@ -3,6 +3,8 @@ id: PreactQueuerOptions
 title: PreactQueuerOptions
 ---
 
+# Interface: PreactQueuerOptions\<TValue, TSelected\>
+
 Defined in: [preact-pacer/src/queuer/useQueuer.ts:9](https://github.com/TanStack/pacer/blob/main/packages/preact-pacer/src/queuer/useQueuer.ts#L9)
 
 ## Extends

--- a/docs/framework/preact/reference/interfaces/PreactRateLimiter.md
+++ b/docs/framework/preact/reference/interfaces/PreactRateLimiter.md
@@ -3,6 +3,8 @@ id: PreactRateLimiter
 title: PreactRateLimiter
 ---
 
+# Interface: PreactRateLimiter\<TFn, TSelected\>
+
 Defined in: [preact-pacer/src/rate-limiter/useRateLimiter.ts:24](https://github.com/TanStack/pacer/blob/main/packages/preact-pacer/src/rate-limiter/useRateLimiter.ts#L24)
 
 ## Extends

--- a/docs/framework/preact/reference/interfaces/PreactRateLimiter.md
+++ b/docs/framework/preact/reference/interfaces/PreactRateLimiter.md
@@ -3,8 +3,6 @@ id: PreactRateLimiter
 title: PreactRateLimiter
 ---
 
-# Interface: PreactRateLimiter\<TFn, TSelected\>
-
 Defined in: [preact-pacer/src/rate-limiter/useRateLimiter.ts:24](https://github.com/TanStack/pacer/blob/main/packages/preact-pacer/src/rate-limiter/useRateLimiter.ts#L24)
 
 ## Extends

--- a/docs/framework/preact/reference/interfaces/PreactRateLimiterOptions.md
+++ b/docs/framework/preact/reference/interfaces/PreactRateLimiterOptions.md
@@ -3,8 +3,6 @@ id: PreactRateLimiterOptions
 title: PreactRateLimiterOptions
 ---
 
-# Interface: PreactRateLimiterOptions\<TFn, TSelected\>
-
 Defined in: [preact-pacer/src/rate-limiter/useRateLimiter.ts:13](https://github.com/TanStack/pacer/blob/main/packages/preact-pacer/src/rate-limiter/useRateLimiter.ts#L13)
 
 ## Extends

--- a/docs/framework/preact/reference/interfaces/PreactRateLimiterOptions.md
+++ b/docs/framework/preact/reference/interfaces/PreactRateLimiterOptions.md
@@ -3,6 +3,8 @@ id: PreactRateLimiterOptions
 title: PreactRateLimiterOptions
 ---
 
+# Interface: PreactRateLimiterOptions\<TFn, TSelected\>
+
 Defined in: [preact-pacer/src/rate-limiter/useRateLimiter.ts:13](https://github.com/TanStack/pacer/blob/main/packages/preact-pacer/src/rate-limiter/useRateLimiter.ts#L13)
 
 ## Extends

--- a/docs/framework/preact/reference/interfaces/PreactThrottler.md
+++ b/docs/framework/preact/reference/interfaces/PreactThrottler.md
@@ -3,6 +3,8 @@ id: PreactThrottler
 title: PreactThrottler
 ---
 
+# Interface: PreactThrottler\<TFn, TSelected\>
+
 Defined in: [preact-pacer/src/throttler/useThrottler.ts:24](https://github.com/TanStack/pacer/blob/main/packages/preact-pacer/src/throttler/useThrottler.ts#L24)
 
 ## Extends

--- a/docs/framework/preact/reference/interfaces/PreactThrottler.md
+++ b/docs/framework/preact/reference/interfaces/PreactThrottler.md
@@ -3,8 +3,6 @@ id: PreactThrottler
 title: PreactThrottler
 ---
 
-# Interface: PreactThrottler\<TFn, TSelected\>
-
 Defined in: [preact-pacer/src/throttler/useThrottler.ts:24](https://github.com/TanStack/pacer/blob/main/packages/preact-pacer/src/throttler/useThrottler.ts#L24)
 
 ## Extends

--- a/docs/framework/preact/reference/interfaces/PreactThrottlerOptions.md
+++ b/docs/framework/preact/reference/interfaces/PreactThrottlerOptions.md
@@ -3,6 +3,8 @@ id: PreactThrottlerOptions
 title: PreactThrottlerOptions
 ---
 
+# Interface: PreactThrottlerOptions\<TFn, TSelected\>
+
 Defined in: [preact-pacer/src/throttler/useThrottler.ts:13](https://github.com/TanStack/pacer/blob/main/packages/preact-pacer/src/throttler/useThrottler.ts#L13)
 
 ## Extends

--- a/docs/framework/preact/reference/interfaces/PreactThrottlerOptions.md
+++ b/docs/framework/preact/reference/interfaces/PreactThrottlerOptions.md
@@ -3,8 +3,6 @@ id: PreactThrottlerOptions
 title: PreactThrottlerOptions
 ---
 
-# Interface: PreactThrottlerOptions\<TFn, TSelected\>
-
 Defined in: [preact-pacer/src/throttler/useThrottler.ts:13](https://github.com/TanStack/pacer/blob/main/packages/preact-pacer/src/throttler/useThrottler.ts#L13)
 
 ## Extends

--- a/docs/framework/react/reference/functions/PacerProvider.md
+++ b/docs/framework/react/reference/functions/PacerProvider.md
@@ -3,8 +3,6 @@ id: PacerProvider
 title: PacerProvider
 ---
 
-# Function: PacerProvider()
-
 ```ts
 function PacerProvider(__namedParameters): Element;
 ```

--- a/docs/framework/react/reference/functions/PacerProvider.md
+++ b/docs/framework/react/reference/functions/PacerProvider.md
@@ -3,6 +3,8 @@ id: PacerProvider
 title: PacerProvider
 ---
 
+# Function: PacerProvider()
+
 ```ts
 function PacerProvider(__namedParameters): Element;
 ```

--- a/docs/framework/react/reference/functions/useAsyncBatchedCallback.md
+++ b/docs/framework/react/reference/functions/useAsyncBatchedCallback.md
@@ -3,8 +3,6 @@ id: useAsyncBatchedCallback
 title: useAsyncBatchedCallback
 ---
 
-# Function: useAsyncBatchedCallback()
-
 ```ts
 function useAsyncBatchedCallback<TValue>(fn, options): (item) => Promise<void>;
 ```

--- a/docs/framework/react/reference/functions/useAsyncBatchedCallback.md
+++ b/docs/framework/react/reference/functions/useAsyncBatchedCallback.md
@@ -3,6 +3,8 @@ id: useAsyncBatchedCallback
 title: useAsyncBatchedCallback
 ---
 
+# Function: useAsyncBatchedCallback()
+
 ```ts
 function useAsyncBatchedCallback<TValue>(fn, options): (item) => Promise<void>;
 ```

--- a/docs/framework/react/reference/functions/useAsyncBatcher.md
+++ b/docs/framework/react/reference/functions/useAsyncBatcher.md
@@ -3,8 +3,6 @@ id: useAsyncBatcher
 title: useAsyncBatcher
 ---
 
-# Function: useAsyncBatcher()
-
 ```ts
 function useAsyncBatcher<TValue, TSelected>(
    fn, 

--- a/docs/framework/react/reference/functions/useAsyncBatcher.md
+++ b/docs/framework/react/reference/functions/useAsyncBatcher.md
@@ -3,6 +3,8 @@ id: useAsyncBatcher
 title: useAsyncBatcher
 ---
 
+# Function: useAsyncBatcher()
+
 ```ts
 function useAsyncBatcher<TValue, TSelected>(
    fn, 

--- a/docs/framework/react/reference/functions/useAsyncDebouncedCallback.md
+++ b/docs/framework/react/reference/functions/useAsyncDebouncedCallback.md
@@ -3,6 +3,8 @@ id: useAsyncDebouncedCallback
 title: useAsyncDebouncedCallback
 ---
 
+# Function: useAsyncDebouncedCallback()
+
 ```ts
 function useAsyncDebouncedCallback<TFn>(fn, options): (...args) => Promise<Awaited<ReturnType<TFn>> | undefined>;
 ```

--- a/docs/framework/react/reference/functions/useAsyncDebouncedCallback.md
+++ b/docs/framework/react/reference/functions/useAsyncDebouncedCallback.md
@@ -3,8 +3,6 @@ id: useAsyncDebouncedCallback
 title: useAsyncDebouncedCallback
 ---
 
-# Function: useAsyncDebouncedCallback()
-
 ```ts
 function useAsyncDebouncedCallback<TFn>(fn, options): (...args) => Promise<Awaited<ReturnType<TFn>> | undefined>;
 ```

--- a/docs/framework/react/reference/functions/useAsyncDebouncer.md
+++ b/docs/framework/react/reference/functions/useAsyncDebouncer.md
@@ -3,8 +3,6 @@ id: useAsyncDebouncer
 title: useAsyncDebouncer
 ---
 
-# Function: useAsyncDebouncer()
-
 ```ts
 function useAsyncDebouncer<TFn, TSelected>(
    fn, 

--- a/docs/framework/react/reference/functions/useAsyncDebouncer.md
+++ b/docs/framework/react/reference/functions/useAsyncDebouncer.md
@@ -3,6 +3,8 @@ id: useAsyncDebouncer
 title: useAsyncDebouncer
 ---
 
+# Function: useAsyncDebouncer()
+
 ```ts
 function useAsyncDebouncer<TFn, TSelected>(
    fn, 

--- a/docs/framework/react/reference/functions/useAsyncQueuedState.md
+++ b/docs/framework/react/reference/functions/useAsyncQueuedState.md
@@ -3,8 +3,6 @@ id: useAsyncQueuedState
 title: useAsyncQueuedState
 ---
 
-# Function: useAsyncQueuedState()
-
 ```ts
 function useAsyncQueuedState<TValue, TSelected>(
    fn, 

--- a/docs/framework/react/reference/functions/useAsyncQueuedState.md
+++ b/docs/framework/react/reference/functions/useAsyncQueuedState.md
@@ -3,6 +3,8 @@ id: useAsyncQueuedState
 title: useAsyncQueuedState
 ---
 
+# Function: useAsyncQueuedState()
+
 ```ts
 function useAsyncQueuedState<TValue, TSelected>(
    fn, 

--- a/docs/framework/react/reference/functions/useAsyncQueuer.md
+++ b/docs/framework/react/reference/functions/useAsyncQueuer.md
@@ -3,6 +3,8 @@ id: useAsyncQueuer
 title: useAsyncQueuer
 ---
 
+# Function: useAsyncQueuer()
+
 ```ts
 function useAsyncQueuer<TValue, TSelected>(
    fn, 

--- a/docs/framework/react/reference/functions/useAsyncQueuer.md
+++ b/docs/framework/react/reference/functions/useAsyncQueuer.md
@@ -3,8 +3,6 @@ id: useAsyncQueuer
 title: useAsyncQueuer
 ---
 
-# Function: useAsyncQueuer()
-
 ```ts
 function useAsyncQueuer<TValue, TSelected>(
    fn, 

--- a/docs/framework/react/reference/functions/useAsyncRateLimitedCallback.md
+++ b/docs/framework/react/reference/functions/useAsyncRateLimitedCallback.md
@@ -3,8 +3,6 @@ id: useAsyncRateLimitedCallback
 title: useAsyncRateLimitedCallback
 ---
 
-# Function: useAsyncRateLimitedCallback()
-
 ```ts
 function useAsyncRateLimitedCallback<TFn>(fn, options): (...args) => Promise<Awaited<ReturnType<TFn>> | undefined>;
 ```

--- a/docs/framework/react/reference/functions/useAsyncRateLimitedCallback.md
+++ b/docs/framework/react/reference/functions/useAsyncRateLimitedCallback.md
@@ -3,6 +3,8 @@ id: useAsyncRateLimitedCallback
 title: useAsyncRateLimitedCallback
 ---
 
+# Function: useAsyncRateLimitedCallback()
+
 ```ts
 function useAsyncRateLimitedCallback<TFn>(fn, options): (...args) => Promise<Awaited<ReturnType<TFn>> | undefined>;
 ```

--- a/docs/framework/react/reference/functions/useAsyncRateLimiter.md
+++ b/docs/framework/react/reference/functions/useAsyncRateLimiter.md
@@ -3,8 +3,6 @@ id: useAsyncRateLimiter
 title: useAsyncRateLimiter
 ---
 
-# Function: useAsyncRateLimiter()
-
 ```ts
 function useAsyncRateLimiter<TFn, TSelected>(
    fn, 

--- a/docs/framework/react/reference/functions/useAsyncRateLimiter.md
+++ b/docs/framework/react/reference/functions/useAsyncRateLimiter.md
@@ -3,6 +3,8 @@ id: useAsyncRateLimiter
 title: useAsyncRateLimiter
 ---
 
+# Function: useAsyncRateLimiter()
+
 ```ts
 function useAsyncRateLimiter<TFn, TSelected>(
    fn, 

--- a/docs/framework/react/reference/functions/useAsyncThrottledCallback.md
+++ b/docs/framework/react/reference/functions/useAsyncThrottledCallback.md
@@ -3,8 +3,6 @@ id: useAsyncThrottledCallback
 title: useAsyncThrottledCallback
 ---
 
-# Function: useAsyncThrottledCallback()
-
 ```ts
 function useAsyncThrottledCallback<TFn>(fn, options): (...args) => Promise<Awaited<ReturnType<TFn>> | undefined>;
 ```

--- a/docs/framework/react/reference/functions/useAsyncThrottledCallback.md
+++ b/docs/framework/react/reference/functions/useAsyncThrottledCallback.md
@@ -3,6 +3,8 @@ id: useAsyncThrottledCallback
 title: useAsyncThrottledCallback
 ---
 
+# Function: useAsyncThrottledCallback()
+
 ```ts
 function useAsyncThrottledCallback<TFn>(fn, options): (...args) => Promise<Awaited<ReturnType<TFn>> | undefined>;
 ```

--- a/docs/framework/react/reference/functions/useAsyncThrottler.md
+++ b/docs/framework/react/reference/functions/useAsyncThrottler.md
@@ -3,6 +3,8 @@ id: useAsyncThrottler
 title: useAsyncThrottler
 ---
 
+# Function: useAsyncThrottler()
+
 ```ts
 function useAsyncThrottler<TFn, TSelected>(
    fn, 

--- a/docs/framework/react/reference/functions/useAsyncThrottler.md
+++ b/docs/framework/react/reference/functions/useAsyncThrottler.md
@@ -3,8 +3,6 @@ id: useAsyncThrottler
 title: useAsyncThrottler
 ---
 
-# Function: useAsyncThrottler()
-
 ```ts
 function useAsyncThrottler<TFn, TSelected>(
    fn, 

--- a/docs/framework/react/reference/functions/useBatchedCallback.md
+++ b/docs/framework/react/reference/functions/useBatchedCallback.md
@@ -3,6 +3,8 @@ id: useBatchedCallback
 title: useBatchedCallback
 ---
 
+# Function: useBatchedCallback()
+
 ```ts
 function useBatchedCallback<TValue>(fn, options): (item) => void;
 ```

--- a/docs/framework/react/reference/functions/useBatchedCallback.md
+++ b/docs/framework/react/reference/functions/useBatchedCallback.md
@@ -3,8 +3,6 @@ id: useBatchedCallback
 title: useBatchedCallback
 ---
 
-# Function: useBatchedCallback()
-
 ```ts
 function useBatchedCallback<TValue>(fn, options): (item) => void;
 ```

--- a/docs/framework/react/reference/functions/useBatcher.md
+++ b/docs/framework/react/reference/functions/useBatcher.md
@@ -3,6 +3,8 @@ id: useBatcher
 title: useBatcher
 ---
 
+# Function: useBatcher()
+
 ```ts
 function useBatcher<TValue, TSelected>(
    fn, 

--- a/docs/framework/react/reference/functions/useBatcher.md
+++ b/docs/framework/react/reference/functions/useBatcher.md
@@ -3,8 +3,6 @@ id: useBatcher
 title: useBatcher
 ---
 
-# Function: useBatcher()
-
 ```ts
 function useBatcher<TValue, TSelected>(
    fn, 

--- a/docs/framework/react/reference/functions/useDebouncedCallback.md
+++ b/docs/framework/react/reference/functions/useDebouncedCallback.md
@@ -3,8 +3,6 @@ id: useDebouncedCallback
 title: useDebouncedCallback
 ---
 
-# Function: useDebouncedCallback()
-
 ```ts
 function useDebouncedCallback<TFn>(fn, options): (...args) => void;
 ```

--- a/docs/framework/react/reference/functions/useDebouncedCallback.md
+++ b/docs/framework/react/reference/functions/useDebouncedCallback.md
@@ -3,6 +3,8 @@ id: useDebouncedCallback
 title: useDebouncedCallback
 ---
 
+# Function: useDebouncedCallback()
+
 ```ts
 function useDebouncedCallback<TFn>(fn, options): (...args) => void;
 ```

--- a/docs/framework/react/reference/functions/useDebouncedState.md
+++ b/docs/framework/react/reference/functions/useDebouncedState.md
@@ -3,8 +3,6 @@ id: useDebouncedState
 title: useDebouncedState
 ---
 
-# Function: useDebouncedState()
-
 ```ts
 function useDebouncedState<TValue, TSelected>(
    value, 

--- a/docs/framework/react/reference/functions/useDebouncedState.md
+++ b/docs/framework/react/reference/functions/useDebouncedState.md
@@ -3,6 +3,8 @@ id: useDebouncedState
 title: useDebouncedState
 ---
 
+# Function: useDebouncedState()
+
 ```ts
 function useDebouncedState<TValue, TSelected>(
    value, 

--- a/docs/framework/react/reference/functions/useDebouncedValue.md
+++ b/docs/framework/react/reference/functions/useDebouncedValue.md
@@ -3,8 +3,6 @@ id: useDebouncedValue
 title: useDebouncedValue
 ---
 
-# Function: useDebouncedValue()
-
 ```ts
 function useDebouncedValue<TValue, TSelected>(
    value, 

--- a/docs/framework/react/reference/functions/useDebouncedValue.md
+++ b/docs/framework/react/reference/functions/useDebouncedValue.md
@@ -3,6 +3,8 @@ id: useDebouncedValue
 title: useDebouncedValue
 ---
 
+# Function: useDebouncedValue()
+
 ```ts
 function useDebouncedValue<TValue, TSelected>(
    value, 

--- a/docs/framework/react/reference/functions/useDebouncer.md
+++ b/docs/framework/react/reference/functions/useDebouncer.md
@@ -3,8 +3,6 @@ id: useDebouncer
 title: useDebouncer
 ---
 
-# Function: useDebouncer()
-
 ```ts
 function useDebouncer<TFn, TSelected>(
    fn, 

--- a/docs/framework/react/reference/functions/useDebouncer.md
+++ b/docs/framework/react/reference/functions/useDebouncer.md
@@ -3,6 +3,8 @@ id: useDebouncer
 title: useDebouncer
 ---
 
+# Function: useDebouncer()
+
 ```ts
 function useDebouncer<TFn, TSelected>(
    fn, 

--- a/docs/framework/react/reference/functions/useDefaultPacerOptions.md
+++ b/docs/framework/react/reference/functions/useDefaultPacerOptions.md
@@ -3,6 +3,8 @@ id: useDefaultPacerOptions
 title: useDefaultPacerOptions
 ---
 
+# Function: useDefaultPacerOptions()
+
 ```ts
 function useDefaultPacerOptions(): PacerProviderOptions;
 ```

--- a/docs/framework/react/reference/functions/useDefaultPacerOptions.md
+++ b/docs/framework/react/reference/functions/useDefaultPacerOptions.md
@@ -3,8 +3,6 @@ id: useDefaultPacerOptions
 title: useDefaultPacerOptions
 ---
 
-# Function: useDefaultPacerOptions()
-
 ```ts
 function useDefaultPacerOptions(): PacerProviderOptions;
 ```

--- a/docs/framework/react/reference/functions/usePacerContext.md
+++ b/docs/framework/react/reference/functions/usePacerContext.md
@@ -3,8 +3,6 @@ id: usePacerContext
 title: usePacerContext
 ---
 
-# Function: usePacerContext()
-
 ```ts
 function usePacerContext(): PacerContextValue | null;
 ```

--- a/docs/framework/react/reference/functions/usePacerContext.md
+++ b/docs/framework/react/reference/functions/usePacerContext.md
@@ -3,6 +3,8 @@ id: usePacerContext
 title: usePacerContext
 ---
 
+# Function: usePacerContext()
+
 ```ts
 function usePacerContext(): PacerContextValue | null;
 ```

--- a/docs/framework/react/reference/functions/useQueuedState.md
+++ b/docs/framework/react/reference/functions/useQueuedState.md
@@ -3,8 +3,6 @@ id: useQueuedState
 title: useQueuedState
 ---
 
-# Function: useQueuedState()
-
 ```ts
 function useQueuedState<TValue, TSelected>(
    fn, 

--- a/docs/framework/react/reference/functions/useQueuedState.md
+++ b/docs/framework/react/reference/functions/useQueuedState.md
@@ -3,6 +3,8 @@ id: useQueuedState
 title: useQueuedState
 ---
 
+# Function: useQueuedState()
+
 ```ts
 function useQueuedState<TValue, TSelected>(
    fn, 

--- a/docs/framework/react/reference/functions/useQueuedValue.md
+++ b/docs/framework/react/reference/functions/useQueuedValue.md
@@ -3,6 +3,8 @@ id: useQueuedValue
 title: useQueuedValue
 ---
 
+# Function: useQueuedValue()
+
 ```ts
 function useQueuedValue<TValue, TSelected>(
    initialValue, 

--- a/docs/framework/react/reference/functions/useQueuedValue.md
+++ b/docs/framework/react/reference/functions/useQueuedValue.md
@@ -3,8 +3,6 @@ id: useQueuedValue
 title: useQueuedValue
 ---
 
-# Function: useQueuedValue()
-
 ```ts
 function useQueuedValue<TValue, TSelected>(
    initialValue, 

--- a/docs/framework/react/reference/functions/useQueuer.md
+++ b/docs/framework/react/reference/functions/useQueuer.md
@@ -3,6 +3,8 @@ id: useQueuer
 title: useQueuer
 ---
 
+# Function: useQueuer()
+
 ```ts
 function useQueuer<TValue, TSelected>(
    fn, 

--- a/docs/framework/react/reference/functions/useQueuer.md
+++ b/docs/framework/react/reference/functions/useQueuer.md
@@ -3,8 +3,6 @@ id: useQueuer
 title: useQueuer
 ---
 
-# Function: useQueuer()
-
 ```ts
 function useQueuer<TValue, TSelected>(
    fn, 

--- a/docs/framework/react/reference/functions/useRateLimitedCallback.md
+++ b/docs/framework/react/reference/functions/useRateLimitedCallback.md
@@ -3,8 +3,6 @@ id: useRateLimitedCallback
 title: useRateLimitedCallback
 ---
 
-# Function: useRateLimitedCallback()
-
 ```ts
 function useRateLimitedCallback<TFn>(fn, options): (...args) => boolean;
 ```

--- a/docs/framework/react/reference/functions/useRateLimitedCallback.md
+++ b/docs/framework/react/reference/functions/useRateLimitedCallback.md
@@ -3,6 +3,8 @@ id: useRateLimitedCallback
 title: useRateLimitedCallback
 ---
 
+# Function: useRateLimitedCallback()
+
 ```ts
 function useRateLimitedCallback<TFn>(fn, options): (...args) => boolean;
 ```

--- a/docs/framework/react/reference/functions/useRateLimitedState.md
+++ b/docs/framework/react/reference/functions/useRateLimitedState.md
@@ -3,8 +3,6 @@ id: useRateLimitedState
 title: useRateLimitedState
 ---
 
-# Function: useRateLimitedState()
-
 ```ts
 function useRateLimitedState<TValue, TSelected>(
    value, 

--- a/docs/framework/react/reference/functions/useRateLimitedState.md
+++ b/docs/framework/react/reference/functions/useRateLimitedState.md
@@ -3,6 +3,8 @@ id: useRateLimitedState
 title: useRateLimitedState
 ---
 
+# Function: useRateLimitedState()
+
 ```ts
 function useRateLimitedState<TValue, TSelected>(
    value, 

--- a/docs/framework/react/reference/functions/useRateLimitedValue.md
+++ b/docs/framework/react/reference/functions/useRateLimitedValue.md
@@ -3,6 +3,8 @@ id: useRateLimitedValue
 title: useRateLimitedValue
 ---
 
+# Function: useRateLimitedValue()
+
 ```ts
 function useRateLimitedValue<TValue, TSelected>(
    value, 

--- a/docs/framework/react/reference/functions/useRateLimitedValue.md
+++ b/docs/framework/react/reference/functions/useRateLimitedValue.md
@@ -3,8 +3,6 @@ id: useRateLimitedValue
 title: useRateLimitedValue
 ---
 
-# Function: useRateLimitedValue()
-
 ```ts
 function useRateLimitedValue<TValue, TSelected>(
    value, 

--- a/docs/framework/react/reference/functions/useRateLimiter.md
+++ b/docs/framework/react/reference/functions/useRateLimiter.md
@@ -3,6 +3,8 @@ id: useRateLimiter
 title: useRateLimiter
 ---
 
+# Function: useRateLimiter()
+
 ```ts
 function useRateLimiter<TFn, TSelected>(
    fn, 

--- a/docs/framework/react/reference/functions/useRateLimiter.md
+++ b/docs/framework/react/reference/functions/useRateLimiter.md
@@ -3,8 +3,6 @@ id: useRateLimiter
 title: useRateLimiter
 ---
 
-# Function: useRateLimiter()
-
 ```ts
 function useRateLimiter<TFn, TSelected>(
    fn, 

--- a/docs/framework/react/reference/functions/useThrottledCallback.md
+++ b/docs/framework/react/reference/functions/useThrottledCallback.md
@@ -3,6 +3,8 @@ id: useThrottledCallback
 title: useThrottledCallback
 ---
 
+# Function: useThrottledCallback()
+
 ```ts
 function useThrottledCallback<TFn>(fn, options): (...args) => void;
 ```

--- a/docs/framework/react/reference/functions/useThrottledCallback.md
+++ b/docs/framework/react/reference/functions/useThrottledCallback.md
@@ -3,8 +3,6 @@ id: useThrottledCallback
 title: useThrottledCallback
 ---
 
-# Function: useThrottledCallback()
-
 ```ts
 function useThrottledCallback<TFn>(fn, options): (...args) => void;
 ```

--- a/docs/framework/react/reference/functions/useThrottledState.md
+++ b/docs/framework/react/reference/functions/useThrottledState.md
@@ -3,6 +3,8 @@ id: useThrottledState
 title: useThrottledState
 ---
 
+# Function: useThrottledState()
+
 ```ts
 function useThrottledState<TValue, TSelected>(
    value, 

--- a/docs/framework/react/reference/functions/useThrottledState.md
+++ b/docs/framework/react/reference/functions/useThrottledState.md
@@ -3,8 +3,6 @@ id: useThrottledState
 title: useThrottledState
 ---
 
-# Function: useThrottledState()
-
 ```ts
 function useThrottledState<TValue, TSelected>(
    value, 

--- a/docs/framework/react/reference/functions/useThrottledValue.md
+++ b/docs/framework/react/reference/functions/useThrottledValue.md
@@ -3,6 +3,8 @@ id: useThrottledValue
 title: useThrottledValue
 ---
 
+# Function: useThrottledValue()
+
 ```ts
 function useThrottledValue<TValue, TSelected>(
    value, 

--- a/docs/framework/react/reference/functions/useThrottledValue.md
+++ b/docs/framework/react/reference/functions/useThrottledValue.md
@@ -3,8 +3,6 @@ id: useThrottledValue
 title: useThrottledValue
 ---
 
-# Function: useThrottledValue()
-
 ```ts
 function useThrottledValue<TValue, TSelected>(
    value, 

--- a/docs/framework/react/reference/functions/useThrottler.md
+++ b/docs/framework/react/reference/functions/useThrottler.md
@@ -3,8 +3,6 @@ id: useThrottler
 title: useThrottler
 ---
 
-# Function: useThrottler()
-
 ```ts
 function useThrottler<TFn, TSelected>(
    fn, 

--- a/docs/framework/react/reference/functions/useThrottler.md
+++ b/docs/framework/react/reference/functions/useThrottler.md
@@ -3,6 +3,8 @@ id: useThrottler
 title: useThrottler
 ---
 
+# Function: useThrottler()
+
 ```ts
 function useThrottler<TFn, TSelected>(
    fn, 

--- a/docs/framework/react/reference/index.md
+++ b/docs/framework/react/reference/index.md
@@ -3,6 +3,8 @@ id: "@tanstack/react-pacer"
 title: "@tanstack/react-pacer"
 ---
 
+# @tanstack/react-pacer
+
 ## Interfaces
 
 - [PacerProviderOptions](interfaces/PacerProviderOptions.md)

--- a/docs/framework/react/reference/index.md
+++ b/docs/framework/react/reference/index.md
@@ -3,8 +3,6 @@ id: "@tanstack/react-pacer"
 title: "@tanstack/react-pacer"
 ---
 
-# @tanstack/react-pacer
-
 ## Interfaces
 
 - [PacerProviderOptions](interfaces/PacerProviderOptions.md)

--- a/docs/framework/react/reference/interfaces/PacerProviderOptions.md
+++ b/docs/framework/react/reference/interfaces/PacerProviderOptions.md
@@ -3,6 +3,8 @@ id: PacerProviderOptions
 title: PacerProviderOptions
 ---
 
+# Interface: PacerProviderOptions
+
 Defined in: [react-pacer/src/provider/PacerProvider.tsx:22](https://github.com/TanStack/pacer/blob/main/packages/react-pacer/src/provider/PacerProvider.tsx#L22)
 
 ## Properties

--- a/docs/framework/react/reference/interfaces/PacerProviderOptions.md
+++ b/docs/framework/react/reference/interfaces/PacerProviderOptions.md
@@ -3,8 +3,6 @@ id: PacerProviderOptions
 title: PacerProviderOptions
 ---
 
-# Interface: PacerProviderOptions
-
 Defined in: [react-pacer/src/provider/PacerProvider.tsx:22](https://github.com/TanStack/pacer/blob/main/packages/react-pacer/src/provider/PacerProvider.tsx#L22)
 
 ## Properties

--- a/docs/framework/react/reference/interfaces/PacerProviderProps.md
+++ b/docs/framework/react/reference/interfaces/PacerProviderProps.md
@@ -3,6 +3,8 @@ id: PacerProviderProps
 title: PacerProviderProps
 ---
 
+# Interface: PacerProviderProps
+
 Defined in: [react-pacer/src/provider/PacerProvider.tsx:41](https://github.com/TanStack/pacer/blob/main/packages/react-pacer/src/provider/PacerProvider.tsx#L41)
 
 ## Properties

--- a/docs/framework/react/reference/interfaces/PacerProviderProps.md
+++ b/docs/framework/react/reference/interfaces/PacerProviderProps.md
@@ -3,8 +3,6 @@ id: PacerProviderProps
 title: PacerProviderProps
 ---
 
-# Interface: PacerProviderProps
-
 Defined in: [react-pacer/src/provider/PacerProvider.tsx:41](https://github.com/TanStack/pacer/blob/main/packages/react-pacer/src/provider/PacerProvider.tsx#L41)
 
 ## Properties

--- a/docs/framework/react/reference/interfaces/ReactAsyncBatcher.md
+++ b/docs/framework/react/reference/interfaces/ReactAsyncBatcher.md
@@ -3,8 +3,6 @@ id: ReactAsyncBatcher
 title: ReactAsyncBatcher
 ---
 
-# Interface: ReactAsyncBatcher\<TValue, TSelected\>
-
 Defined in: [react-pacer/src/async-batcher/useAsyncBatcher.ts:23](https://github.com/TanStack/pacer/blob/main/packages/react-pacer/src/async-batcher/useAsyncBatcher.ts#L23)
 
 ## Extends

--- a/docs/framework/react/reference/interfaces/ReactAsyncBatcher.md
+++ b/docs/framework/react/reference/interfaces/ReactAsyncBatcher.md
@@ -3,6 +3,8 @@ id: ReactAsyncBatcher
 title: ReactAsyncBatcher
 ---
 
+# Interface: ReactAsyncBatcher\<TValue, TSelected\>
+
 Defined in: [react-pacer/src/async-batcher/useAsyncBatcher.ts:23](https://github.com/TanStack/pacer/blob/main/packages/react-pacer/src/async-batcher/useAsyncBatcher.ts#L23)
 
 ## Extends

--- a/docs/framework/react/reference/interfaces/ReactAsyncBatcherOptions.md
+++ b/docs/framework/react/reference/interfaces/ReactAsyncBatcherOptions.md
@@ -3,8 +3,6 @@ id: ReactAsyncBatcherOptions
 title: ReactAsyncBatcherOptions
 ---
 
-# Interface: ReactAsyncBatcherOptions\<TValue, TSelected\>
-
 Defined in: [react-pacer/src/async-batcher/useAsyncBatcher.ts:12](https://github.com/TanStack/pacer/blob/main/packages/react-pacer/src/async-batcher/useAsyncBatcher.ts#L12)
 
 ## Extends

--- a/docs/framework/react/reference/interfaces/ReactAsyncBatcherOptions.md
+++ b/docs/framework/react/reference/interfaces/ReactAsyncBatcherOptions.md
@@ -3,6 +3,8 @@ id: ReactAsyncBatcherOptions
 title: ReactAsyncBatcherOptions
 ---
 
+# Interface: ReactAsyncBatcherOptions\<TValue, TSelected\>
+
 Defined in: [react-pacer/src/async-batcher/useAsyncBatcher.ts:12](https://github.com/TanStack/pacer/blob/main/packages/react-pacer/src/async-batcher/useAsyncBatcher.ts#L12)
 
 ## Extends

--- a/docs/framework/react/reference/interfaces/ReactAsyncDebouncer.md
+++ b/docs/framework/react/reference/interfaces/ReactAsyncDebouncer.md
@@ -3,8 +3,6 @@ id: ReactAsyncDebouncer
 title: ReactAsyncDebouncer
 ---
 
-# Interface: ReactAsyncDebouncer\<TFn, TSelected\>
-
 Defined in: [react-pacer/src/async-debouncer/useAsyncDebouncer.ts:24](https://github.com/TanStack/pacer/blob/main/packages/react-pacer/src/async-debouncer/useAsyncDebouncer.ts#L24)
 
 ## Extends

--- a/docs/framework/react/reference/interfaces/ReactAsyncDebouncer.md
+++ b/docs/framework/react/reference/interfaces/ReactAsyncDebouncer.md
@@ -3,6 +3,8 @@ id: ReactAsyncDebouncer
 title: ReactAsyncDebouncer
 ---
 
+# Interface: ReactAsyncDebouncer\<TFn, TSelected\>
+
 Defined in: [react-pacer/src/async-debouncer/useAsyncDebouncer.ts:24](https://github.com/TanStack/pacer/blob/main/packages/react-pacer/src/async-debouncer/useAsyncDebouncer.ts#L24)
 
 ## Extends

--- a/docs/framework/react/reference/interfaces/ReactAsyncDebouncerOptions.md
+++ b/docs/framework/react/reference/interfaces/ReactAsyncDebouncerOptions.md
@@ -3,8 +3,6 @@ id: ReactAsyncDebouncerOptions
 title: ReactAsyncDebouncerOptions
 ---
 
-# Interface: ReactAsyncDebouncerOptions\<TFn, TSelected\>
-
 Defined in: [react-pacer/src/async-debouncer/useAsyncDebouncer.ts:13](https://github.com/TanStack/pacer/blob/main/packages/react-pacer/src/async-debouncer/useAsyncDebouncer.ts#L13)
 
 ## Extends

--- a/docs/framework/react/reference/interfaces/ReactAsyncDebouncerOptions.md
+++ b/docs/framework/react/reference/interfaces/ReactAsyncDebouncerOptions.md
@@ -3,6 +3,8 @@ id: ReactAsyncDebouncerOptions
 title: ReactAsyncDebouncerOptions
 ---
 
+# Interface: ReactAsyncDebouncerOptions\<TFn, TSelected\>
+
 Defined in: [react-pacer/src/async-debouncer/useAsyncDebouncer.ts:13](https://github.com/TanStack/pacer/blob/main/packages/react-pacer/src/async-debouncer/useAsyncDebouncer.ts#L13)
 
 ## Extends

--- a/docs/framework/react/reference/interfaces/ReactAsyncQueuer.md
+++ b/docs/framework/react/reference/interfaces/ReactAsyncQueuer.md
@@ -3,6 +3,8 @@ id: ReactAsyncQueuer
 title: ReactAsyncQueuer
 ---
 
+# Interface: ReactAsyncQueuer\<TValue, TSelected\>
+
 Defined in: [react-pacer/src/async-queuer/useAsyncQueuer.ts:23](https://github.com/TanStack/pacer/blob/main/packages/react-pacer/src/async-queuer/useAsyncQueuer.ts#L23)
 
 ## Extends

--- a/docs/framework/react/reference/interfaces/ReactAsyncQueuer.md
+++ b/docs/framework/react/reference/interfaces/ReactAsyncQueuer.md
@@ -3,8 +3,6 @@ id: ReactAsyncQueuer
 title: ReactAsyncQueuer
 ---
 
-# Interface: ReactAsyncQueuer\<TValue, TSelected\>
-
 Defined in: [react-pacer/src/async-queuer/useAsyncQueuer.ts:23](https://github.com/TanStack/pacer/blob/main/packages/react-pacer/src/async-queuer/useAsyncQueuer.ts#L23)
 
 ## Extends

--- a/docs/framework/react/reference/interfaces/ReactAsyncQueuerOptions.md
+++ b/docs/framework/react/reference/interfaces/ReactAsyncQueuerOptions.md
@@ -3,6 +3,8 @@ id: ReactAsyncQueuerOptions
 title: ReactAsyncQueuerOptions
 ---
 
+# Interface: ReactAsyncQueuerOptions\<TValue, TSelected\>
+
 Defined in: [react-pacer/src/async-queuer/useAsyncQueuer.ts:12](https://github.com/TanStack/pacer/blob/main/packages/react-pacer/src/async-queuer/useAsyncQueuer.ts#L12)
 
 ## Extends

--- a/docs/framework/react/reference/interfaces/ReactAsyncQueuerOptions.md
+++ b/docs/framework/react/reference/interfaces/ReactAsyncQueuerOptions.md
@@ -3,8 +3,6 @@ id: ReactAsyncQueuerOptions
 title: ReactAsyncQueuerOptions
 ---
 
-# Interface: ReactAsyncQueuerOptions\<TValue, TSelected\>
-
 Defined in: [react-pacer/src/async-queuer/useAsyncQueuer.ts:12](https://github.com/TanStack/pacer/blob/main/packages/react-pacer/src/async-queuer/useAsyncQueuer.ts#L12)
 
 ## Extends

--- a/docs/framework/react/reference/interfaces/ReactAsyncRateLimiter.md
+++ b/docs/framework/react/reference/interfaces/ReactAsyncRateLimiter.md
@@ -3,6 +3,8 @@ id: ReactAsyncRateLimiter
 title: ReactAsyncRateLimiter
 ---
 
+# Interface: ReactAsyncRateLimiter\<TFn, TSelected\>
+
 Defined in: [react-pacer/src/async-rate-limiter/useAsyncRateLimiter.ts:24](https://github.com/TanStack/pacer/blob/main/packages/react-pacer/src/async-rate-limiter/useAsyncRateLimiter.ts#L24)
 
 ## Extends

--- a/docs/framework/react/reference/interfaces/ReactAsyncRateLimiter.md
+++ b/docs/framework/react/reference/interfaces/ReactAsyncRateLimiter.md
@@ -3,8 +3,6 @@ id: ReactAsyncRateLimiter
 title: ReactAsyncRateLimiter
 ---
 
-# Interface: ReactAsyncRateLimiter\<TFn, TSelected\>
-
 Defined in: [react-pacer/src/async-rate-limiter/useAsyncRateLimiter.ts:24](https://github.com/TanStack/pacer/blob/main/packages/react-pacer/src/async-rate-limiter/useAsyncRateLimiter.ts#L24)
 
 ## Extends

--- a/docs/framework/react/reference/interfaces/ReactAsyncRateLimiterOptions.md
+++ b/docs/framework/react/reference/interfaces/ReactAsyncRateLimiterOptions.md
@@ -3,8 +3,6 @@ id: ReactAsyncRateLimiterOptions
 title: ReactAsyncRateLimiterOptions
 ---
 
-# Interface: ReactAsyncRateLimiterOptions\<TFn, TSelected\>
-
 Defined in: [react-pacer/src/async-rate-limiter/useAsyncRateLimiter.ts:13](https://github.com/TanStack/pacer/blob/main/packages/react-pacer/src/async-rate-limiter/useAsyncRateLimiter.ts#L13)
 
 ## Extends

--- a/docs/framework/react/reference/interfaces/ReactAsyncRateLimiterOptions.md
+++ b/docs/framework/react/reference/interfaces/ReactAsyncRateLimiterOptions.md
@@ -3,6 +3,8 @@ id: ReactAsyncRateLimiterOptions
 title: ReactAsyncRateLimiterOptions
 ---
 
+# Interface: ReactAsyncRateLimiterOptions\<TFn, TSelected\>
+
 Defined in: [react-pacer/src/async-rate-limiter/useAsyncRateLimiter.ts:13](https://github.com/TanStack/pacer/blob/main/packages/react-pacer/src/async-rate-limiter/useAsyncRateLimiter.ts#L13)
 
 ## Extends

--- a/docs/framework/react/reference/interfaces/ReactAsyncThrottler.md
+++ b/docs/framework/react/reference/interfaces/ReactAsyncThrottler.md
@@ -3,6 +3,8 @@ id: ReactAsyncThrottler
 title: ReactAsyncThrottler
 ---
 
+# Interface: ReactAsyncThrottler\<TFn, TSelected\>
+
 Defined in: [react-pacer/src/async-throttler/useAsyncThrottler.ts:24](https://github.com/TanStack/pacer/blob/main/packages/react-pacer/src/async-throttler/useAsyncThrottler.ts#L24)
 
 ## Extends

--- a/docs/framework/react/reference/interfaces/ReactAsyncThrottler.md
+++ b/docs/framework/react/reference/interfaces/ReactAsyncThrottler.md
@@ -3,8 +3,6 @@ id: ReactAsyncThrottler
 title: ReactAsyncThrottler
 ---
 
-# Interface: ReactAsyncThrottler\<TFn, TSelected\>
-
 Defined in: [react-pacer/src/async-throttler/useAsyncThrottler.ts:24](https://github.com/TanStack/pacer/blob/main/packages/react-pacer/src/async-throttler/useAsyncThrottler.ts#L24)
 
 ## Extends

--- a/docs/framework/react/reference/interfaces/ReactAsyncThrottlerOptions.md
+++ b/docs/framework/react/reference/interfaces/ReactAsyncThrottlerOptions.md
@@ -3,8 +3,6 @@ id: ReactAsyncThrottlerOptions
 title: ReactAsyncThrottlerOptions
 ---
 
-# Interface: ReactAsyncThrottlerOptions\<TFn, TSelected\>
-
 Defined in: [react-pacer/src/async-throttler/useAsyncThrottler.ts:13](https://github.com/TanStack/pacer/blob/main/packages/react-pacer/src/async-throttler/useAsyncThrottler.ts#L13)
 
 ## Extends

--- a/docs/framework/react/reference/interfaces/ReactAsyncThrottlerOptions.md
+++ b/docs/framework/react/reference/interfaces/ReactAsyncThrottlerOptions.md
@@ -3,6 +3,8 @@ id: ReactAsyncThrottlerOptions
 title: ReactAsyncThrottlerOptions
 ---
 
+# Interface: ReactAsyncThrottlerOptions\<TFn, TSelected\>
+
 Defined in: [react-pacer/src/async-throttler/useAsyncThrottler.ts:13](https://github.com/TanStack/pacer/blob/main/packages/react-pacer/src/async-throttler/useAsyncThrottler.ts#L13)
 
 ## Extends

--- a/docs/framework/react/reference/interfaces/ReactBatcher.md
+++ b/docs/framework/react/reference/interfaces/ReactBatcher.md
@@ -3,6 +3,8 @@ id: ReactBatcher
 title: ReactBatcher
 ---
 
+# Interface: ReactBatcher\<TValue, TSelected\>
+
 Defined in: [react-pacer/src/batcher/useBatcher.ts:20](https://github.com/TanStack/pacer/blob/main/packages/react-pacer/src/batcher/useBatcher.ts#L20)
 
 ## Extends

--- a/docs/framework/react/reference/interfaces/ReactBatcher.md
+++ b/docs/framework/react/reference/interfaces/ReactBatcher.md
@@ -3,8 +3,6 @@ id: ReactBatcher
 title: ReactBatcher
 ---
 
-# Interface: ReactBatcher\<TValue, TSelected\>
-
 Defined in: [react-pacer/src/batcher/useBatcher.ts:20](https://github.com/TanStack/pacer/blob/main/packages/react-pacer/src/batcher/useBatcher.ts#L20)
 
 ## Extends

--- a/docs/framework/react/reference/interfaces/ReactBatcherOptions.md
+++ b/docs/framework/react/reference/interfaces/ReactBatcherOptions.md
@@ -3,8 +3,6 @@ id: ReactBatcherOptions
 title: ReactBatcherOptions
 ---
 
-# Interface: ReactBatcherOptions\<TValue, TSelected\>
-
 Defined in: [react-pacer/src/batcher/useBatcher.ts:9](https://github.com/TanStack/pacer/blob/main/packages/react-pacer/src/batcher/useBatcher.ts#L9)
 
 ## Extends

--- a/docs/framework/react/reference/interfaces/ReactBatcherOptions.md
+++ b/docs/framework/react/reference/interfaces/ReactBatcherOptions.md
@@ -3,6 +3,8 @@ id: ReactBatcherOptions
 title: ReactBatcherOptions
 ---
 
+# Interface: ReactBatcherOptions\<TValue, TSelected\>
+
 Defined in: [react-pacer/src/batcher/useBatcher.ts:9](https://github.com/TanStack/pacer/blob/main/packages/react-pacer/src/batcher/useBatcher.ts#L9)
 
 ## Extends

--- a/docs/framework/react/reference/interfaces/ReactDebouncer.md
+++ b/docs/framework/react/reference/interfaces/ReactDebouncer.md
@@ -3,6 +3,8 @@ id: ReactDebouncer
 title: ReactDebouncer
 ---
 
+# Interface: ReactDebouncer\<TFn, TSelected\>
+
 Defined in: [react-pacer/src/debouncer/useDebouncer.ts:24](https://github.com/TanStack/pacer/blob/main/packages/react-pacer/src/debouncer/useDebouncer.ts#L24)
 
 ## Extends

--- a/docs/framework/react/reference/interfaces/ReactDebouncer.md
+++ b/docs/framework/react/reference/interfaces/ReactDebouncer.md
@@ -3,8 +3,6 @@ id: ReactDebouncer
 title: ReactDebouncer
 ---
 
-# Interface: ReactDebouncer\<TFn, TSelected\>
-
 Defined in: [react-pacer/src/debouncer/useDebouncer.ts:24](https://github.com/TanStack/pacer/blob/main/packages/react-pacer/src/debouncer/useDebouncer.ts#L24)
 
 ## Extends

--- a/docs/framework/react/reference/interfaces/ReactDebouncerOptions.md
+++ b/docs/framework/react/reference/interfaces/ReactDebouncerOptions.md
@@ -3,6 +3,8 @@ id: ReactDebouncerOptions
 title: ReactDebouncerOptions
 ---
 
+# Interface: ReactDebouncerOptions\<TFn, TSelected\>
+
 Defined in: [react-pacer/src/debouncer/useDebouncer.ts:13](https://github.com/TanStack/pacer/blob/main/packages/react-pacer/src/debouncer/useDebouncer.ts#L13)
 
 ## Extends

--- a/docs/framework/react/reference/interfaces/ReactDebouncerOptions.md
+++ b/docs/framework/react/reference/interfaces/ReactDebouncerOptions.md
@@ -3,8 +3,6 @@ id: ReactDebouncerOptions
 title: ReactDebouncerOptions
 ---
 
-# Interface: ReactDebouncerOptions\<TFn, TSelected\>
-
 Defined in: [react-pacer/src/debouncer/useDebouncer.ts:13](https://github.com/TanStack/pacer/blob/main/packages/react-pacer/src/debouncer/useDebouncer.ts#L13)
 
 ## Extends

--- a/docs/framework/react/reference/interfaces/ReactQueuer.md
+++ b/docs/framework/react/reference/interfaces/ReactQueuer.md
@@ -3,8 +3,6 @@ id: ReactQueuer
 title: ReactQueuer
 ---
 
-# Interface: ReactQueuer\<TValue, TSelected\>
-
 Defined in: [react-pacer/src/queuer/useQueuer.ts:20](https://github.com/TanStack/pacer/blob/main/packages/react-pacer/src/queuer/useQueuer.ts#L20)
 
 ## Extends

--- a/docs/framework/react/reference/interfaces/ReactQueuer.md
+++ b/docs/framework/react/reference/interfaces/ReactQueuer.md
@@ -3,6 +3,8 @@ id: ReactQueuer
 title: ReactQueuer
 ---
 
+# Interface: ReactQueuer\<TValue, TSelected\>
+
 Defined in: [react-pacer/src/queuer/useQueuer.ts:20](https://github.com/TanStack/pacer/blob/main/packages/react-pacer/src/queuer/useQueuer.ts#L20)
 
 ## Extends

--- a/docs/framework/react/reference/interfaces/ReactQueuerOptions.md
+++ b/docs/framework/react/reference/interfaces/ReactQueuerOptions.md
@@ -3,8 +3,6 @@ id: ReactQueuerOptions
 title: ReactQueuerOptions
 ---
 
-# Interface: ReactQueuerOptions\<TValue, TSelected\>
-
 Defined in: [react-pacer/src/queuer/useQueuer.ts:9](https://github.com/TanStack/pacer/blob/main/packages/react-pacer/src/queuer/useQueuer.ts#L9)
 
 ## Extends

--- a/docs/framework/react/reference/interfaces/ReactQueuerOptions.md
+++ b/docs/framework/react/reference/interfaces/ReactQueuerOptions.md
@@ -3,6 +3,8 @@ id: ReactQueuerOptions
 title: ReactQueuerOptions
 ---
 
+# Interface: ReactQueuerOptions\<TValue, TSelected\>
+
 Defined in: [react-pacer/src/queuer/useQueuer.ts:9](https://github.com/TanStack/pacer/blob/main/packages/react-pacer/src/queuer/useQueuer.ts#L9)
 
 ## Extends

--- a/docs/framework/react/reference/interfaces/ReactRateLimiter.md
+++ b/docs/framework/react/reference/interfaces/ReactRateLimiter.md
@@ -3,8 +3,6 @@ id: ReactRateLimiter
 title: ReactRateLimiter
 ---
 
-# Interface: ReactRateLimiter\<TFn, TSelected\>
-
 Defined in: [react-pacer/src/rate-limiter/useRateLimiter.ts:24](https://github.com/TanStack/pacer/blob/main/packages/react-pacer/src/rate-limiter/useRateLimiter.ts#L24)
 
 ## Extends

--- a/docs/framework/react/reference/interfaces/ReactRateLimiter.md
+++ b/docs/framework/react/reference/interfaces/ReactRateLimiter.md
@@ -3,6 +3,8 @@ id: ReactRateLimiter
 title: ReactRateLimiter
 ---
 
+# Interface: ReactRateLimiter\<TFn, TSelected\>
+
 Defined in: [react-pacer/src/rate-limiter/useRateLimiter.ts:24](https://github.com/TanStack/pacer/blob/main/packages/react-pacer/src/rate-limiter/useRateLimiter.ts#L24)
 
 ## Extends

--- a/docs/framework/react/reference/interfaces/ReactRateLimiterOptions.md
+++ b/docs/framework/react/reference/interfaces/ReactRateLimiterOptions.md
@@ -3,8 +3,6 @@ id: ReactRateLimiterOptions
 title: ReactRateLimiterOptions
 ---
 
-# Interface: ReactRateLimiterOptions\<TFn, TSelected\>
-
 Defined in: [react-pacer/src/rate-limiter/useRateLimiter.ts:13](https://github.com/TanStack/pacer/blob/main/packages/react-pacer/src/rate-limiter/useRateLimiter.ts#L13)
 
 ## Extends

--- a/docs/framework/react/reference/interfaces/ReactRateLimiterOptions.md
+++ b/docs/framework/react/reference/interfaces/ReactRateLimiterOptions.md
@@ -3,6 +3,8 @@ id: ReactRateLimiterOptions
 title: ReactRateLimiterOptions
 ---
 
+# Interface: ReactRateLimiterOptions\<TFn, TSelected\>
+
 Defined in: [react-pacer/src/rate-limiter/useRateLimiter.ts:13](https://github.com/TanStack/pacer/blob/main/packages/react-pacer/src/rate-limiter/useRateLimiter.ts#L13)
 
 ## Extends

--- a/docs/framework/react/reference/interfaces/ReactThrottler.md
+++ b/docs/framework/react/reference/interfaces/ReactThrottler.md
@@ -3,6 +3,8 @@ id: ReactThrottler
 title: ReactThrottler
 ---
 
+# Interface: ReactThrottler\<TFn, TSelected\>
+
 Defined in: [react-pacer/src/throttler/useThrottler.ts:24](https://github.com/TanStack/pacer/blob/main/packages/react-pacer/src/throttler/useThrottler.ts#L24)
 
 ## Extends

--- a/docs/framework/react/reference/interfaces/ReactThrottler.md
+++ b/docs/framework/react/reference/interfaces/ReactThrottler.md
@@ -3,8 +3,6 @@ id: ReactThrottler
 title: ReactThrottler
 ---
 
-# Interface: ReactThrottler\<TFn, TSelected\>
-
 Defined in: [react-pacer/src/throttler/useThrottler.ts:24](https://github.com/TanStack/pacer/blob/main/packages/react-pacer/src/throttler/useThrottler.ts#L24)
 
 ## Extends

--- a/docs/framework/react/reference/interfaces/ReactThrottlerOptions.md
+++ b/docs/framework/react/reference/interfaces/ReactThrottlerOptions.md
@@ -3,6 +3,8 @@ id: ReactThrottlerOptions
 title: ReactThrottlerOptions
 ---
 
+# Interface: ReactThrottlerOptions\<TFn, TSelected\>
+
 Defined in: [react-pacer/src/throttler/useThrottler.ts:13](https://github.com/TanStack/pacer/blob/main/packages/react-pacer/src/throttler/useThrottler.ts#L13)
 
 ## Extends

--- a/docs/framework/react/reference/interfaces/ReactThrottlerOptions.md
+++ b/docs/framework/react/reference/interfaces/ReactThrottlerOptions.md
@@ -3,8 +3,6 @@ id: ReactThrottlerOptions
 title: ReactThrottlerOptions
 ---
 
-# Interface: ReactThrottlerOptions\<TFn, TSelected\>
-
 Defined in: [react-pacer/src/throttler/useThrottler.ts:13](https://github.com/TanStack/pacer/blob/main/packages/react-pacer/src/throttler/useThrottler.ts#L13)
 
 ## Extends

--- a/docs/framework/solid/reference/functions/PacerProvider.md
+++ b/docs/framework/solid/reference/functions/PacerProvider.md
@@ -3,8 +3,6 @@ id: PacerProvider
 title: PacerProvider
 ---
 
-# Function: PacerProvider()
-
 ```ts
 function PacerProvider(props): Element;
 ```

--- a/docs/framework/solid/reference/functions/PacerProvider.md
+++ b/docs/framework/solid/reference/functions/PacerProvider.md
@@ -3,6 +3,8 @@ id: PacerProvider
 title: PacerProvider
 ---
 
+# Function: PacerProvider()
+
 ```ts
 function PacerProvider(props): Element;
 ```

--- a/docs/framework/solid/reference/functions/createAsyncBatcher.md
+++ b/docs/framework/solid/reference/functions/createAsyncBatcher.md
@@ -3,6 +3,8 @@ id: createAsyncBatcher
 title: createAsyncBatcher
 ---
 
+# Function: createAsyncBatcher()
+
 ```ts
 function createAsyncBatcher<TValue, TSelected>(
    fn, 

--- a/docs/framework/solid/reference/functions/createAsyncBatcher.md
+++ b/docs/framework/solid/reference/functions/createAsyncBatcher.md
@@ -3,8 +3,6 @@ id: createAsyncBatcher
 title: createAsyncBatcher
 ---
 
-# Function: createAsyncBatcher()
-
 ```ts
 function createAsyncBatcher<TValue, TSelected>(
    fn, 

--- a/docs/framework/solid/reference/functions/createAsyncDebouncer.md
+++ b/docs/framework/solid/reference/functions/createAsyncDebouncer.md
@@ -3,8 +3,6 @@ id: createAsyncDebouncer
 title: createAsyncDebouncer
 ---
 
-# Function: createAsyncDebouncer()
-
 ```ts
 function createAsyncDebouncer<TFn, TSelected>(
    fn, 

--- a/docs/framework/solid/reference/functions/createAsyncDebouncer.md
+++ b/docs/framework/solid/reference/functions/createAsyncDebouncer.md
@@ -3,6 +3,8 @@ id: createAsyncDebouncer
 title: createAsyncDebouncer
 ---
 
+# Function: createAsyncDebouncer()
+
 ```ts
 function createAsyncDebouncer<TFn, TSelected>(
    fn, 

--- a/docs/framework/solid/reference/functions/createAsyncQueuer.md
+++ b/docs/framework/solid/reference/functions/createAsyncQueuer.md
@@ -3,6 +3,8 @@ id: createAsyncQueuer
 title: createAsyncQueuer
 ---
 
+# Function: createAsyncQueuer()
+
 ```ts
 function createAsyncQueuer<TValue, TSelected>(
    fn, 

--- a/docs/framework/solid/reference/functions/createAsyncQueuer.md
+++ b/docs/framework/solid/reference/functions/createAsyncQueuer.md
@@ -3,8 +3,6 @@ id: createAsyncQueuer
 title: createAsyncQueuer
 ---
 
-# Function: createAsyncQueuer()
-
 ```ts
 function createAsyncQueuer<TValue, TSelected>(
    fn, 

--- a/docs/framework/solid/reference/functions/createAsyncRateLimiter.md
+++ b/docs/framework/solid/reference/functions/createAsyncRateLimiter.md
@@ -3,6 +3,8 @@ id: createAsyncRateLimiter
 title: createAsyncRateLimiter
 ---
 
+# Function: createAsyncRateLimiter()
+
 ```ts
 function createAsyncRateLimiter<TFn, TSelected>(
    fn, 

--- a/docs/framework/solid/reference/functions/createAsyncRateLimiter.md
+++ b/docs/framework/solid/reference/functions/createAsyncRateLimiter.md
@@ -3,8 +3,6 @@ id: createAsyncRateLimiter
 title: createAsyncRateLimiter
 ---
 
-# Function: createAsyncRateLimiter()
-
 ```ts
 function createAsyncRateLimiter<TFn, TSelected>(
    fn, 

--- a/docs/framework/solid/reference/functions/createAsyncThrottler.md
+++ b/docs/framework/solid/reference/functions/createAsyncThrottler.md
@@ -3,6 +3,8 @@ id: createAsyncThrottler
 title: createAsyncThrottler
 ---
 
+# Function: createAsyncThrottler()
+
 ```ts
 function createAsyncThrottler<TFn, TSelected>(
    fn, 

--- a/docs/framework/solid/reference/functions/createAsyncThrottler.md
+++ b/docs/framework/solid/reference/functions/createAsyncThrottler.md
@@ -3,8 +3,6 @@ id: createAsyncThrottler
 title: createAsyncThrottler
 ---
 
-# Function: createAsyncThrottler()
-
 ```ts
 function createAsyncThrottler<TFn, TSelected>(
    fn, 

--- a/docs/framework/solid/reference/functions/createBatcher.md
+++ b/docs/framework/solid/reference/functions/createBatcher.md
@@ -3,8 +3,6 @@ id: createBatcher
 title: createBatcher
 ---
 
-# Function: createBatcher()
-
 ```ts
 function createBatcher<TValue, TSelected>(
    fn, 

--- a/docs/framework/solid/reference/functions/createBatcher.md
+++ b/docs/framework/solid/reference/functions/createBatcher.md
@@ -3,6 +3,8 @@ id: createBatcher
 title: createBatcher
 ---
 
+# Function: createBatcher()
+
 ```ts
 function createBatcher<TValue, TSelected>(
    fn, 

--- a/docs/framework/solid/reference/functions/createDebouncedSignal.md
+++ b/docs/framework/solid/reference/functions/createDebouncedSignal.md
@@ -3,8 +3,6 @@ id: createDebouncedSignal
 title: createDebouncedSignal
 ---
 
-# Function: createDebouncedSignal()
-
 ```ts
 function createDebouncedSignal<TValue, TSelected>(
    value, 

--- a/docs/framework/solid/reference/functions/createDebouncedSignal.md
+++ b/docs/framework/solid/reference/functions/createDebouncedSignal.md
@@ -3,6 +3,8 @@ id: createDebouncedSignal
 title: createDebouncedSignal
 ---
 
+# Function: createDebouncedSignal()
+
 ```ts
 function createDebouncedSignal<TValue, TSelected>(
    value, 

--- a/docs/framework/solid/reference/functions/createDebouncedValue.md
+++ b/docs/framework/solid/reference/functions/createDebouncedValue.md
@@ -3,8 +3,6 @@ id: createDebouncedValue
 title: createDebouncedValue
 ---
 
-# Function: createDebouncedValue()
-
 ```ts
 function createDebouncedValue<TValue, TSelected>(
    value, 

--- a/docs/framework/solid/reference/functions/createDebouncedValue.md
+++ b/docs/framework/solid/reference/functions/createDebouncedValue.md
@@ -3,6 +3,8 @@ id: createDebouncedValue
 title: createDebouncedValue
 ---
 
+# Function: createDebouncedValue()
+
 ```ts
 function createDebouncedValue<TValue, TSelected>(
    value, 

--- a/docs/framework/solid/reference/functions/createDebouncer.md
+++ b/docs/framework/solid/reference/functions/createDebouncer.md
@@ -3,8 +3,6 @@ id: createDebouncer
 title: createDebouncer
 ---
 
-# Function: createDebouncer()
-
 ```ts
 function createDebouncer<TFn, TSelected>(
    fn, 

--- a/docs/framework/solid/reference/functions/createDebouncer.md
+++ b/docs/framework/solid/reference/functions/createDebouncer.md
@@ -3,6 +3,8 @@ id: createDebouncer
 title: createDebouncer
 ---
 
+# Function: createDebouncer()
+
 ```ts
 function createDebouncer<TFn, TSelected>(
    fn, 

--- a/docs/framework/solid/reference/functions/createQueuedSignal.md
+++ b/docs/framework/solid/reference/functions/createQueuedSignal.md
@@ -3,8 +3,6 @@ id: createQueuedSignal
 title: createQueuedSignal
 ---
 
-# Function: createQueuedSignal()
-
 ```ts
 function createQueuedSignal<TValue, TSelected>(
    fn, 

--- a/docs/framework/solid/reference/functions/createQueuedSignal.md
+++ b/docs/framework/solid/reference/functions/createQueuedSignal.md
@@ -3,6 +3,8 @@ id: createQueuedSignal
 title: createQueuedSignal
 ---
 
+# Function: createQueuedSignal()
+
 ```ts
 function createQueuedSignal<TValue, TSelected>(
    fn, 

--- a/docs/framework/solid/reference/functions/createQueuer.md
+++ b/docs/framework/solid/reference/functions/createQueuer.md
@@ -3,8 +3,6 @@ id: createQueuer
 title: createQueuer
 ---
 
-# Function: createQueuer()
-
 ```ts
 function createQueuer<TValue, TSelected>(
    fn, 

--- a/docs/framework/solid/reference/functions/createQueuer.md
+++ b/docs/framework/solid/reference/functions/createQueuer.md
@@ -3,6 +3,8 @@ id: createQueuer
 title: createQueuer
 ---
 
+# Function: createQueuer()
+
 ```ts
 function createQueuer<TValue, TSelected>(
    fn, 

--- a/docs/framework/solid/reference/functions/createRateLimitedSignal.md
+++ b/docs/framework/solid/reference/functions/createRateLimitedSignal.md
@@ -3,8 +3,6 @@ id: createRateLimitedSignal
 title: createRateLimitedSignal
 ---
 
-# Function: createRateLimitedSignal()
-
 ```ts
 function createRateLimitedSignal<TValue, TSelected>(
    value, 

--- a/docs/framework/solid/reference/functions/createRateLimitedSignal.md
+++ b/docs/framework/solid/reference/functions/createRateLimitedSignal.md
@@ -3,6 +3,8 @@ id: createRateLimitedSignal
 title: createRateLimitedSignal
 ---
 
+# Function: createRateLimitedSignal()
+
 ```ts
 function createRateLimitedSignal<TValue, TSelected>(
    value, 

--- a/docs/framework/solid/reference/functions/createRateLimitedValue.md
+++ b/docs/framework/solid/reference/functions/createRateLimitedValue.md
@@ -3,8 +3,6 @@ id: createRateLimitedValue
 title: createRateLimitedValue
 ---
 
-# Function: createRateLimitedValue()
-
 ```ts
 function createRateLimitedValue<TValue, TSelected>(
    value, 

--- a/docs/framework/solid/reference/functions/createRateLimitedValue.md
+++ b/docs/framework/solid/reference/functions/createRateLimitedValue.md
@@ -3,6 +3,8 @@ id: createRateLimitedValue
 title: createRateLimitedValue
 ---
 
+# Function: createRateLimitedValue()
+
 ```ts
 function createRateLimitedValue<TValue, TSelected>(
    value, 

--- a/docs/framework/solid/reference/functions/createRateLimiter.md
+++ b/docs/framework/solid/reference/functions/createRateLimiter.md
@@ -3,8 +3,6 @@ id: createRateLimiter
 title: createRateLimiter
 ---
 
-# Function: createRateLimiter()
-
 ```ts
 function createRateLimiter<TFn, TSelected>(
    fn, 

--- a/docs/framework/solid/reference/functions/createRateLimiter.md
+++ b/docs/framework/solid/reference/functions/createRateLimiter.md
@@ -3,6 +3,8 @@ id: createRateLimiter
 title: createRateLimiter
 ---
 
+# Function: createRateLimiter()
+
 ```ts
 function createRateLimiter<TFn, TSelected>(
    fn, 

--- a/docs/framework/solid/reference/functions/createThrottledSignal.md
+++ b/docs/framework/solid/reference/functions/createThrottledSignal.md
@@ -3,8 +3,6 @@ id: createThrottledSignal
 title: createThrottledSignal
 ---
 
-# Function: createThrottledSignal()
-
 ```ts
 function createThrottledSignal<TValue, TSelected>(
    value, 

--- a/docs/framework/solid/reference/functions/createThrottledSignal.md
+++ b/docs/framework/solid/reference/functions/createThrottledSignal.md
@@ -3,6 +3,8 @@ id: createThrottledSignal
 title: createThrottledSignal
 ---
 
+# Function: createThrottledSignal()
+
 ```ts
 function createThrottledSignal<TValue, TSelected>(
    value, 

--- a/docs/framework/solid/reference/functions/createThrottledValue.md
+++ b/docs/framework/solid/reference/functions/createThrottledValue.md
@@ -3,6 +3,8 @@ id: createThrottledValue
 title: createThrottledValue
 ---
 
+# Function: createThrottledValue()
+
 ```ts
 function createThrottledValue<TValue, TSelected>(
    value, 

--- a/docs/framework/solid/reference/functions/createThrottledValue.md
+++ b/docs/framework/solid/reference/functions/createThrottledValue.md
@@ -3,8 +3,6 @@ id: createThrottledValue
 title: createThrottledValue
 ---
 
-# Function: createThrottledValue()
-
 ```ts
 function createThrottledValue<TValue, TSelected>(
    value, 

--- a/docs/framework/solid/reference/functions/createThrottler.md
+++ b/docs/framework/solid/reference/functions/createThrottler.md
@@ -3,6 +3,8 @@ id: createThrottler
 title: createThrottler
 ---
 
+# Function: createThrottler()
+
 ```ts
 function createThrottler<TFn, TSelected>(
    fn, 

--- a/docs/framework/solid/reference/functions/createThrottler.md
+++ b/docs/framework/solid/reference/functions/createThrottler.md
@@ -3,8 +3,6 @@ id: createThrottler
 title: createThrottler
 ---
 
-# Function: createThrottler()
-
 ```ts
 function createThrottler<TFn, TSelected>(
    fn, 

--- a/docs/framework/solid/reference/functions/useDefaultPacerOptions.md
+++ b/docs/framework/solid/reference/functions/useDefaultPacerOptions.md
@@ -3,6 +3,8 @@ id: useDefaultPacerOptions
 title: useDefaultPacerOptions
 ---
 
+# Function: useDefaultPacerOptions()
+
 ```ts
 function useDefaultPacerOptions(): PacerProviderOptions;
 ```

--- a/docs/framework/solid/reference/functions/useDefaultPacerOptions.md
+++ b/docs/framework/solid/reference/functions/useDefaultPacerOptions.md
@@ -3,8 +3,6 @@ id: useDefaultPacerOptions
 title: useDefaultPacerOptions
 ---
 
-# Function: useDefaultPacerOptions()
-
 ```ts
 function useDefaultPacerOptions(): PacerProviderOptions;
 ```

--- a/docs/framework/solid/reference/functions/usePacerContext.md
+++ b/docs/framework/solid/reference/functions/usePacerContext.md
@@ -3,8 +3,6 @@ id: usePacerContext
 title: usePacerContext
 ---
 
-# Function: usePacerContext()
-
 ```ts
 function usePacerContext(): PacerContextValue | null;
 ```

--- a/docs/framework/solid/reference/functions/usePacerContext.md
+++ b/docs/framework/solid/reference/functions/usePacerContext.md
@@ -3,6 +3,8 @@ id: usePacerContext
 title: usePacerContext
 ---
 
+# Function: usePacerContext()
+
 ```ts
 function usePacerContext(): PacerContextValue | null;
 ```

--- a/docs/framework/solid/reference/index.md
+++ b/docs/framework/solid/reference/index.md
@@ -3,6 +3,8 @@ id: "@tanstack/solid-pacer"
 title: "@tanstack/solid-pacer"
 ---
 
+# @tanstack/solid-pacer
+
 ## Interfaces
 
 - [PacerProviderOptions](interfaces/PacerProviderOptions.md)

--- a/docs/framework/solid/reference/index.md
+++ b/docs/framework/solid/reference/index.md
@@ -3,8 +3,6 @@ id: "@tanstack/solid-pacer"
 title: "@tanstack/solid-pacer"
 ---
 
-# @tanstack/solid-pacer
-
 ## Interfaces
 
 - [PacerProviderOptions](interfaces/PacerProviderOptions.md)

--- a/docs/framework/solid/reference/interfaces/PacerProviderOptions.md
+++ b/docs/framework/solid/reference/interfaces/PacerProviderOptions.md
@@ -3,6 +3,8 @@ id: PacerProviderOptions
 title: PacerProviderOptions
 ---
 
+# Interface: PacerProviderOptions
+
 Defined in: [solid-pacer/src/provider/PacerProvider.tsx:18](https://github.com/TanStack/pacer/blob/main/packages/solid-pacer/src/provider/PacerProvider.tsx#L18)
 
 ## Properties

--- a/docs/framework/solid/reference/interfaces/PacerProviderOptions.md
+++ b/docs/framework/solid/reference/interfaces/PacerProviderOptions.md
@@ -3,8 +3,6 @@ id: PacerProviderOptions
 title: PacerProviderOptions
 ---
 
-# Interface: PacerProviderOptions
-
 Defined in: [solid-pacer/src/provider/PacerProvider.tsx:18](https://github.com/TanStack/pacer/blob/main/packages/solid-pacer/src/provider/PacerProvider.tsx#L18)
 
 ## Properties

--- a/docs/framework/solid/reference/interfaces/PacerProviderProps.md
+++ b/docs/framework/solid/reference/interfaces/PacerProviderProps.md
@@ -3,8 +3,6 @@ id: PacerProviderProps
 title: PacerProviderProps
 ---
 
-# Interface: PacerProviderProps
-
 Defined in: [solid-pacer/src/provider/PacerProvider.tsx:37](https://github.com/TanStack/pacer/blob/main/packages/solid-pacer/src/provider/PacerProvider.tsx#L37)
 
 ## Properties

--- a/docs/framework/solid/reference/interfaces/PacerProviderProps.md
+++ b/docs/framework/solid/reference/interfaces/PacerProviderProps.md
@@ -3,6 +3,8 @@ id: PacerProviderProps
 title: PacerProviderProps
 ---
 
+# Interface: PacerProviderProps
+
 Defined in: [solid-pacer/src/provider/PacerProvider.tsx:37](https://github.com/TanStack/pacer/blob/main/packages/solid-pacer/src/provider/PacerProvider.tsx#L37)
 
 ## Properties

--- a/docs/framework/solid/reference/interfaces/SolidAsyncBatcher.md
+++ b/docs/framework/solid/reference/interfaces/SolidAsyncBatcher.md
@@ -3,6 +3,8 @@ id: SolidAsyncBatcher
 title: SolidAsyncBatcher
 ---
 
+# Interface: SolidAsyncBatcher\<TValue, TSelected\>
+
 Defined in: [solid-pacer/src/async-batcher/createAsyncBatcher.ts:23](https://github.com/TanStack/pacer/blob/main/packages/solid-pacer/src/async-batcher/createAsyncBatcher.ts#L23)
 
 ## Extends

--- a/docs/framework/solid/reference/interfaces/SolidAsyncBatcher.md
+++ b/docs/framework/solid/reference/interfaces/SolidAsyncBatcher.md
@@ -3,8 +3,6 @@ id: SolidAsyncBatcher
 title: SolidAsyncBatcher
 ---
 
-# Interface: SolidAsyncBatcher\<TValue, TSelected\>
-
 Defined in: [solid-pacer/src/async-batcher/createAsyncBatcher.ts:23](https://github.com/TanStack/pacer/blob/main/packages/solid-pacer/src/async-batcher/createAsyncBatcher.ts#L23)
 
 ## Extends

--- a/docs/framework/solid/reference/interfaces/SolidAsyncBatcherOptions.md
+++ b/docs/framework/solid/reference/interfaces/SolidAsyncBatcherOptions.md
@@ -3,6 +3,8 @@ id: SolidAsyncBatcherOptions
 title: SolidAsyncBatcherOptions
 ---
 
+# Interface: SolidAsyncBatcherOptions\<TValue, TSelected\>
+
 Defined in: [solid-pacer/src/async-batcher/createAsyncBatcher.ts:12](https://github.com/TanStack/pacer/blob/main/packages/solid-pacer/src/async-batcher/createAsyncBatcher.ts#L12)
 
 ## Extends

--- a/docs/framework/solid/reference/interfaces/SolidAsyncBatcherOptions.md
+++ b/docs/framework/solid/reference/interfaces/SolidAsyncBatcherOptions.md
@@ -3,8 +3,6 @@ id: SolidAsyncBatcherOptions
 title: SolidAsyncBatcherOptions
 ---
 
-# Interface: SolidAsyncBatcherOptions\<TValue, TSelected\>
-
 Defined in: [solid-pacer/src/async-batcher/createAsyncBatcher.ts:12](https://github.com/TanStack/pacer/blob/main/packages/solid-pacer/src/async-batcher/createAsyncBatcher.ts#L12)
 
 ## Extends

--- a/docs/framework/solid/reference/interfaces/SolidAsyncDebouncer.md
+++ b/docs/framework/solid/reference/interfaces/SolidAsyncDebouncer.md
@@ -3,8 +3,6 @@ id: SolidAsyncDebouncer
 title: SolidAsyncDebouncer
 ---
 
-# Interface: SolidAsyncDebouncer\<TFn, TSelected\>
-
 Defined in: [solid-pacer/src/async-debouncer/createAsyncDebouncer.ts:24](https://github.com/TanStack/pacer/blob/main/packages/solid-pacer/src/async-debouncer/createAsyncDebouncer.ts#L24)
 
 ## Extends

--- a/docs/framework/solid/reference/interfaces/SolidAsyncDebouncer.md
+++ b/docs/framework/solid/reference/interfaces/SolidAsyncDebouncer.md
@@ -3,6 +3,8 @@ id: SolidAsyncDebouncer
 title: SolidAsyncDebouncer
 ---
 
+# Interface: SolidAsyncDebouncer\<TFn, TSelected\>
+
 Defined in: [solid-pacer/src/async-debouncer/createAsyncDebouncer.ts:24](https://github.com/TanStack/pacer/blob/main/packages/solid-pacer/src/async-debouncer/createAsyncDebouncer.ts#L24)
 
 ## Extends

--- a/docs/framework/solid/reference/interfaces/SolidAsyncDebouncerOptions.md
+++ b/docs/framework/solid/reference/interfaces/SolidAsyncDebouncerOptions.md
@@ -3,8 +3,6 @@ id: SolidAsyncDebouncerOptions
 title: SolidAsyncDebouncerOptions
 ---
 
-# Interface: SolidAsyncDebouncerOptions\<TFn, TSelected\>
-
 Defined in: [solid-pacer/src/async-debouncer/createAsyncDebouncer.ts:13](https://github.com/TanStack/pacer/blob/main/packages/solid-pacer/src/async-debouncer/createAsyncDebouncer.ts#L13)
 
 ## Extends

--- a/docs/framework/solid/reference/interfaces/SolidAsyncDebouncerOptions.md
+++ b/docs/framework/solid/reference/interfaces/SolidAsyncDebouncerOptions.md
@@ -3,6 +3,8 @@ id: SolidAsyncDebouncerOptions
 title: SolidAsyncDebouncerOptions
 ---
 
+# Interface: SolidAsyncDebouncerOptions\<TFn, TSelected\>
+
 Defined in: [solid-pacer/src/async-debouncer/createAsyncDebouncer.ts:13](https://github.com/TanStack/pacer/blob/main/packages/solid-pacer/src/async-debouncer/createAsyncDebouncer.ts#L13)
 
 ## Extends

--- a/docs/framework/solid/reference/interfaces/SolidAsyncQueuer.md
+++ b/docs/framework/solid/reference/interfaces/SolidAsyncQueuer.md
@@ -3,8 +3,6 @@ id: SolidAsyncQueuer
 title: SolidAsyncQueuer
 ---
 
-# Interface: SolidAsyncQueuer\<TValue, TSelected\>
-
 Defined in: [solid-pacer/src/async-queuer/createAsyncQueuer.ts:23](https://github.com/TanStack/pacer/blob/main/packages/solid-pacer/src/async-queuer/createAsyncQueuer.ts#L23)
 
 ## Extends

--- a/docs/framework/solid/reference/interfaces/SolidAsyncQueuer.md
+++ b/docs/framework/solid/reference/interfaces/SolidAsyncQueuer.md
@@ -3,6 +3,8 @@ id: SolidAsyncQueuer
 title: SolidAsyncQueuer
 ---
 
+# Interface: SolidAsyncQueuer\<TValue, TSelected\>
+
 Defined in: [solid-pacer/src/async-queuer/createAsyncQueuer.ts:23](https://github.com/TanStack/pacer/blob/main/packages/solid-pacer/src/async-queuer/createAsyncQueuer.ts#L23)
 
 ## Extends

--- a/docs/framework/solid/reference/interfaces/SolidAsyncQueuerOptions.md
+++ b/docs/framework/solid/reference/interfaces/SolidAsyncQueuerOptions.md
@@ -3,6 +3,8 @@ id: SolidAsyncQueuerOptions
 title: SolidAsyncQueuerOptions
 ---
 
+# Interface: SolidAsyncQueuerOptions\<TValue, TSelected\>
+
 Defined in: [solid-pacer/src/async-queuer/createAsyncQueuer.ts:12](https://github.com/TanStack/pacer/blob/main/packages/solid-pacer/src/async-queuer/createAsyncQueuer.ts#L12)
 
 ## Extends

--- a/docs/framework/solid/reference/interfaces/SolidAsyncQueuerOptions.md
+++ b/docs/framework/solid/reference/interfaces/SolidAsyncQueuerOptions.md
@@ -3,8 +3,6 @@ id: SolidAsyncQueuerOptions
 title: SolidAsyncQueuerOptions
 ---
 
-# Interface: SolidAsyncQueuerOptions\<TValue, TSelected\>
-
 Defined in: [solid-pacer/src/async-queuer/createAsyncQueuer.ts:12](https://github.com/TanStack/pacer/blob/main/packages/solid-pacer/src/async-queuer/createAsyncQueuer.ts#L12)
 
 ## Extends

--- a/docs/framework/solid/reference/interfaces/SolidAsyncRateLimiter.md
+++ b/docs/framework/solid/reference/interfaces/SolidAsyncRateLimiter.md
@@ -3,8 +3,6 @@ id: SolidAsyncRateLimiter
 title: SolidAsyncRateLimiter
 ---
 
-# Interface: SolidAsyncRateLimiter\<TFn, TSelected\>
-
 Defined in: [solid-pacer/src/async-rate-limiter/createAsyncRateLimiter.ts:24](https://github.com/TanStack/pacer/blob/main/packages/solid-pacer/src/async-rate-limiter/createAsyncRateLimiter.ts#L24)
 
 ## Extends

--- a/docs/framework/solid/reference/interfaces/SolidAsyncRateLimiter.md
+++ b/docs/framework/solid/reference/interfaces/SolidAsyncRateLimiter.md
@@ -3,6 +3,8 @@ id: SolidAsyncRateLimiter
 title: SolidAsyncRateLimiter
 ---
 
+# Interface: SolidAsyncRateLimiter\<TFn, TSelected\>
+
 Defined in: [solid-pacer/src/async-rate-limiter/createAsyncRateLimiter.ts:24](https://github.com/TanStack/pacer/blob/main/packages/solid-pacer/src/async-rate-limiter/createAsyncRateLimiter.ts#L24)
 
 ## Extends

--- a/docs/framework/solid/reference/interfaces/SolidAsyncRateLimiterOptions.md
+++ b/docs/framework/solid/reference/interfaces/SolidAsyncRateLimiterOptions.md
@@ -3,8 +3,6 @@ id: SolidAsyncRateLimiterOptions
 title: SolidAsyncRateLimiterOptions
 ---
 
-# Interface: SolidAsyncRateLimiterOptions\<TFn, TSelected\>
-
 Defined in: [solid-pacer/src/async-rate-limiter/createAsyncRateLimiter.ts:13](https://github.com/TanStack/pacer/blob/main/packages/solid-pacer/src/async-rate-limiter/createAsyncRateLimiter.ts#L13)
 
 ## Extends

--- a/docs/framework/solid/reference/interfaces/SolidAsyncRateLimiterOptions.md
+++ b/docs/framework/solid/reference/interfaces/SolidAsyncRateLimiterOptions.md
@@ -3,6 +3,8 @@ id: SolidAsyncRateLimiterOptions
 title: SolidAsyncRateLimiterOptions
 ---
 
+# Interface: SolidAsyncRateLimiterOptions\<TFn, TSelected\>
+
 Defined in: [solid-pacer/src/async-rate-limiter/createAsyncRateLimiter.ts:13](https://github.com/TanStack/pacer/blob/main/packages/solid-pacer/src/async-rate-limiter/createAsyncRateLimiter.ts#L13)
 
 ## Extends

--- a/docs/framework/solid/reference/interfaces/SolidAsyncThrottler.md
+++ b/docs/framework/solid/reference/interfaces/SolidAsyncThrottler.md
@@ -3,8 +3,6 @@ id: SolidAsyncThrottler
 title: SolidAsyncThrottler
 ---
 
-# Interface: SolidAsyncThrottler\<TFn, TSelected\>
-
 Defined in: [solid-pacer/src/async-throttler/createAsyncThrottler.ts:24](https://github.com/TanStack/pacer/blob/main/packages/solid-pacer/src/async-throttler/createAsyncThrottler.ts#L24)
 
 ## Extends

--- a/docs/framework/solid/reference/interfaces/SolidAsyncThrottler.md
+++ b/docs/framework/solid/reference/interfaces/SolidAsyncThrottler.md
@@ -3,6 +3,8 @@ id: SolidAsyncThrottler
 title: SolidAsyncThrottler
 ---
 
+# Interface: SolidAsyncThrottler\<TFn, TSelected\>
+
 Defined in: [solid-pacer/src/async-throttler/createAsyncThrottler.ts:24](https://github.com/TanStack/pacer/blob/main/packages/solid-pacer/src/async-throttler/createAsyncThrottler.ts#L24)
 
 ## Extends

--- a/docs/framework/solid/reference/interfaces/SolidAsyncThrottlerOptions.md
+++ b/docs/framework/solid/reference/interfaces/SolidAsyncThrottlerOptions.md
@@ -3,6 +3,8 @@ id: SolidAsyncThrottlerOptions
 title: SolidAsyncThrottlerOptions
 ---
 
+# Interface: SolidAsyncThrottlerOptions\<TFn, TSelected\>
+
 Defined in: [solid-pacer/src/async-throttler/createAsyncThrottler.ts:13](https://github.com/TanStack/pacer/blob/main/packages/solid-pacer/src/async-throttler/createAsyncThrottler.ts#L13)
 
 ## Extends

--- a/docs/framework/solid/reference/interfaces/SolidAsyncThrottlerOptions.md
+++ b/docs/framework/solid/reference/interfaces/SolidAsyncThrottlerOptions.md
@@ -3,8 +3,6 @@ id: SolidAsyncThrottlerOptions
 title: SolidAsyncThrottlerOptions
 ---
 
-# Interface: SolidAsyncThrottlerOptions\<TFn, TSelected\>
-
 Defined in: [solid-pacer/src/async-throttler/createAsyncThrottler.ts:13](https://github.com/TanStack/pacer/blob/main/packages/solid-pacer/src/async-throttler/createAsyncThrottler.ts#L13)
 
 ## Extends

--- a/docs/framework/solid/reference/interfaces/SolidBatcher.md
+++ b/docs/framework/solid/reference/interfaces/SolidBatcher.md
@@ -3,6 +3,8 @@ id: SolidBatcher
 title: SolidBatcher
 ---
 
+# Interface: SolidBatcher\<TValue, TSelected\>
+
 Defined in: [solid-pacer/src/batcher/createBatcher.ts:20](https://github.com/TanStack/pacer/blob/main/packages/solid-pacer/src/batcher/createBatcher.ts#L20)
 
 ## Extends

--- a/docs/framework/solid/reference/interfaces/SolidBatcher.md
+++ b/docs/framework/solid/reference/interfaces/SolidBatcher.md
@@ -3,8 +3,6 @@ id: SolidBatcher
 title: SolidBatcher
 ---
 
-# Interface: SolidBatcher\<TValue, TSelected\>
-
 Defined in: [solid-pacer/src/batcher/createBatcher.ts:20](https://github.com/TanStack/pacer/blob/main/packages/solid-pacer/src/batcher/createBatcher.ts#L20)
 
 ## Extends

--- a/docs/framework/solid/reference/interfaces/SolidBatcherOptions.md
+++ b/docs/framework/solid/reference/interfaces/SolidBatcherOptions.md
@@ -3,6 +3,8 @@ id: SolidBatcherOptions
 title: SolidBatcherOptions
 ---
 
+# Interface: SolidBatcherOptions\<TValue, TSelected\>
+
 Defined in: [solid-pacer/src/batcher/createBatcher.ts:9](https://github.com/TanStack/pacer/blob/main/packages/solid-pacer/src/batcher/createBatcher.ts#L9)
 
 ## Extends

--- a/docs/framework/solid/reference/interfaces/SolidBatcherOptions.md
+++ b/docs/framework/solid/reference/interfaces/SolidBatcherOptions.md
@@ -3,8 +3,6 @@ id: SolidBatcherOptions
 title: SolidBatcherOptions
 ---
 
-# Interface: SolidBatcherOptions\<TValue, TSelected\>
-
 Defined in: [solid-pacer/src/batcher/createBatcher.ts:9](https://github.com/TanStack/pacer/blob/main/packages/solid-pacer/src/batcher/createBatcher.ts#L9)
 
 ## Extends

--- a/docs/framework/solid/reference/interfaces/SolidDebouncer.md
+++ b/docs/framework/solid/reference/interfaces/SolidDebouncer.md
@@ -3,8 +3,6 @@ id: SolidDebouncer
 title: SolidDebouncer
 ---
 
-# Interface: SolidDebouncer\<TFn, TSelected\>
-
 Defined in: [solid-pacer/src/debouncer/createDebouncer.ts:24](https://github.com/TanStack/pacer/blob/main/packages/solid-pacer/src/debouncer/createDebouncer.ts#L24)
 
 ## Extends

--- a/docs/framework/solid/reference/interfaces/SolidDebouncer.md
+++ b/docs/framework/solid/reference/interfaces/SolidDebouncer.md
@@ -3,6 +3,8 @@ id: SolidDebouncer
 title: SolidDebouncer
 ---
 
+# Interface: SolidDebouncer\<TFn, TSelected\>
+
 Defined in: [solid-pacer/src/debouncer/createDebouncer.ts:24](https://github.com/TanStack/pacer/blob/main/packages/solid-pacer/src/debouncer/createDebouncer.ts#L24)
 
 ## Extends

--- a/docs/framework/solid/reference/interfaces/SolidDebouncerOptions.md
+++ b/docs/framework/solid/reference/interfaces/SolidDebouncerOptions.md
@@ -3,6 +3,8 @@ id: SolidDebouncerOptions
 title: SolidDebouncerOptions
 ---
 
+# Interface: SolidDebouncerOptions\<TFn, TSelected\>
+
 Defined in: [solid-pacer/src/debouncer/createDebouncer.ts:13](https://github.com/TanStack/pacer/blob/main/packages/solid-pacer/src/debouncer/createDebouncer.ts#L13)
 
 ## Extends

--- a/docs/framework/solid/reference/interfaces/SolidDebouncerOptions.md
+++ b/docs/framework/solid/reference/interfaces/SolidDebouncerOptions.md
@@ -3,8 +3,6 @@ id: SolidDebouncerOptions
 title: SolidDebouncerOptions
 ---
 
-# Interface: SolidDebouncerOptions\<TFn, TSelected\>
-
 Defined in: [solid-pacer/src/debouncer/createDebouncer.ts:13](https://github.com/TanStack/pacer/blob/main/packages/solid-pacer/src/debouncer/createDebouncer.ts#L13)
 
 ## Extends

--- a/docs/framework/solid/reference/interfaces/SolidQueuer.md
+++ b/docs/framework/solid/reference/interfaces/SolidQueuer.md
@@ -3,6 +3,8 @@ id: SolidQueuer
 title: SolidQueuer
 ---
 
+# Interface: SolidQueuer\<TValue, TSelected\>
+
 Defined in: [solid-pacer/src/queuer/createQueuer.ts:20](https://github.com/TanStack/pacer/blob/main/packages/solid-pacer/src/queuer/createQueuer.ts#L20)
 
 ## Extends

--- a/docs/framework/solid/reference/interfaces/SolidQueuer.md
+++ b/docs/framework/solid/reference/interfaces/SolidQueuer.md
@@ -3,8 +3,6 @@ id: SolidQueuer
 title: SolidQueuer
 ---
 
-# Interface: SolidQueuer\<TValue, TSelected\>
-
 Defined in: [solid-pacer/src/queuer/createQueuer.ts:20](https://github.com/TanStack/pacer/blob/main/packages/solid-pacer/src/queuer/createQueuer.ts#L20)
 
 ## Extends

--- a/docs/framework/solid/reference/interfaces/SolidQueuerOptions.md
+++ b/docs/framework/solid/reference/interfaces/SolidQueuerOptions.md
@@ -3,8 +3,6 @@ id: SolidQueuerOptions
 title: SolidQueuerOptions
 ---
 
-# Interface: SolidQueuerOptions\<TValue, TSelected\>
-
 Defined in: [solid-pacer/src/queuer/createQueuer.ts:9](https://github.com/TanStack/pacer/blob/main/packages/solid-pacer/src/queuer/createQueuer.ts#L9)
 
 ## Extends

--- a/docs/framework/solid/reference/interfaces/SolidQueuerOptions.md
+++ b/docs/framework/solid/reference/interfaces/SolidQueuerOptions.md
@@ -3,6 +3,8 @@ id: SolidQueuerOptions
 title: SolidQueuerOptions
 ---
 
+# Interface: SolidQueuerOptions\<TValue, TSelected\>
+
 Defined in: [solid-pacer/src/queuer/createQueuer.ts:9](https://github.com/TanStack/pacer/blob/main/packages/solid-pacer/src/queuer/createQueuer.ts#L9)
 
 ## Extends

--- a/docs/framework/solid/reference/interfaces/SolidRateLimiter.md
+++ b/docs/framework/solid/reference/interfaces/SolidRateLimiter.md
@@ -3,6 +3,8 @@ id: SolidRateLimiter
 title: SolidRateLimiter
 ---
 
+# Interface: SolidRateLimiter\<TFn, TSelected\>
+
 Defined in: [solid-pacer/src/rate-limiter/createRateLimiter.ts:24](https://github.com/TanStack/pacer/blob/main/packages/solid-pacer/src/rate-limiter/createRateLimiter.ts#L24)
 
 ## Extends

--- a/docs/framework/solid/reference/interfaces/SolidRateLimiter.md
+++ b/docs/framework/solid/reference/interfaces/SolidRateLimiter.md
@@ -3,8 +3,6 @@ id: SolidRateLimiter
 title: SolidRateLimiter
 ---
 
-# Interface: SolidRateLimiter\<TFn, TSelected\>
-
 Defined in: [solid-pacer/src/rate-limiter/createRateLimiter.ts:24](https://github.com/TanStack/pacer/blob/main/packages/solid-pacer/src/rate-limiter/createRateLimiter.ts#L24)
 
 ## Extends

--- a/docs/framework/solid/reference/interfaces/SolidRateLimiterOptions.md
+++ b/docs/framework/solid/reference/interfaces/SolidRateLimiterOptions.md
@@ -3,6 +3,8 @@ id: SolidRateLimiterOptions
 title: SolidRateLimiterOptions
 ---
 
+# Interface: SolidRateLimiterOptions\<TFn, TSelected\>
+
 Defined in: [solid-pacer/src/rate-limiter/createRateLimiter.ts:13](https://github.com/TanStack/pacer/blob/main/packages/solid-pacer/src/rate-limiter/createRateLimiter.ts#L13)
 
 ## Extends

--- a/docs/framework/solid/reference/interfaces/SolidRateLimiterOptions.md
+++ b/docs/framework/solid/reference/interfaces/SolidRateLimiterOptions.md
@@ -3,8 +3,6 @@ id: SolidRateLimiterOptions
 title: SolidRateLimiterOptions
 ---
 
-# Interface: SolidRateLimiterOptions\<TFn, TSelected\>
-
 Defined in: [solid-pacer/src/rate-limiter/createRateLimiter.ts:13](https://github.com/TanStack/pacer/blob/main/packages/solid-pacer/src/rate-limiter/createRateLimiter.ts#L13)
 
 ## Extends

--- a/docs/framework/solid/reference/interfaces/SolidThrottler.md
+++ b/docs/framework/solid/reference/interfaces/SolidThrottler.md
@@ -3,8 +3,6 @@ id: SolidThrottler
 title: SolidThrottler
 ---
 
-# Interface: SolidThrottler\<TFn, TSelected\>
-
 Defined in: [solid-pacer/src/throttler/createThrottler.ts:24](https://github.com/TanStack/pacer/blob/main/packages/solid-pacer/src/throttler/createThrottler.ts#L24)
 
 ## Extends

--- a/docs/framework/solid/reference/interfaces/SolidThrottler.md
+++ b/docs/framework/solid/reference/interfaces/SolidThrottler.md
@@ -3,6 +3,8 @@ id: SolidThrottler
 title: SolidThrottler
 ---
 
+# Interface: SolidThrottler\<TFn, TSelected\>
+
 Defined in: [solid-pacer/src/throttler/createThrottler.ts:24](https://github.com/TanStack/pacer/blob/main/packages/solid-pacer/src/throttler/createThrottler.ts#L24)
 
 ## Extends

--- a/docs/framework/solid/reference/interfaces/SolidThrottlerOptions.md
+++ b/docs/framework/solid/reference/interfaces/SolidThrottlerOptions.md
@@ -3,8 +3,6 @@ id: SolidThrottlerOptions
 title: SolidThrottlerOptions
 ---
 
-# Interface: SolidThrottlerOptions\<TFn, TSelected\>
-
 Defined in: [solid-pacer/src/throttler/createThrottler.ts:13](https://github.com/TanStack/pacer/blob/main/packages/solid-pacer/src/throttler/createThrottler.ts#L13)
 
 ## Extends

--- a/docs/framework/solid/reference/interfaces/SolidThrottlerOptions.md
+++ b/docs/framework/solid/reference/interfaces/SolidThrottlerOptions.md
@@ -3,6 +3,8 @@ id: SolidThrottlerOptions
 title: SolidThrottlerOptions
 ---
 
+# Interface: SolidThrottlerOptions\<TFn, TSelected\>
+
 Defined in: [solid-pacer/src/throttler/createThrottler.ts:13](https://github.com/TanStack/pacer/blob/main/packages/solid-pacer/src/throttler/createThrottler.ts#L13)
 
 ## Extends

--- a/docs/reference/classes/AsyncBatcher.md
+++ b/docs/reference/classes/AsyncBatcher.md
@@ -3,8 +3,6 @@ id: AsyncBatcher
 title: AsyncBatcher
 ---
 
-# Class: AsyncBatcher\<TValue\>
-
 Defined in: [async-batcher.ts:265](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/async-batcher.ts#L265)
 
 A class that collects items and processes them in batches asynchronously.

--- a/docs/reference/classes/AsyncBatcher.md
+++ b/docs/reference/classes/AsyncBatcher.md
@@ -3,6 +3,8 @@ id: AsyncBatcher
 title: AsyncBatcher
 ---
 
+# Class: AsyncBatcher\<TValue\>
+
 Defined in: [async-batcher.ts:265](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/async-batcher.ts#L265)
 
 A class that collects items and processes them in batches asynchronously.

--- a/docs/reference/classes/AsyncDebouncer.md
+++ b/docs/reference/classes/AsyncDebouncer.md
@@ -3,6 +3,8 @@ id: AsyncDebouncer
 title: AsyncDebouncer
 ---
 
+# Class: AsyncDebouncer\<TFn\>
+
 Defined in: [async-debouncer.ts:218](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/async-debouncer.ts#L218)
 
 A class that creates an async debounced function.

--- a/docs/reference/classes/AsyncDebouncer.md
+++ b/docs/reference/classes/AsyncDebouncer.md
@@ -3,8 +3,6 @@ id: AsyncDebouncer
 title: AsyncDebouncer
 ---
 
-# Class: AsyncDebouncer\<TFn\>
-
 Defined in: [async-debouncer.ts:218](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/async-debouncer.ts#L218)
 
 A class that creates an async debounced function.

--- a/docs/reference/classes/AsyncQueuer.md
+++ b/docs/reference/classes/AsyncQueuer.md
@@ -3,6 +3,8 @@ id: AsyncQueuer
 title: AsyncQueuer
 ---
 
+# Class: AsyncQueuer\<TValue\>
+
 Defined in: [async-queuer.ts:315](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/async-queuer.ts#L315)
 
 A flexible asynchronous queue for processing tasks with configurable concurrency, priority, and expiration.

--- a/docs/reference/classes/AsyncQueuer.md
+++ b/docs/reference/classes/AsyncQueuer.md
@@ -3,8 +3,6 @@ id: AsyncQueuer
 title: AsyncQueuer
 ---
 
-# Class: AsyncQueuer\<TValue\>
-
 Defined in: [async-queuer.ts:315](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/async-queuer.ts#L315)
 
 A flexible asynchronous queue for processing tasks with configurable concurrency, priority, and expiration.

--- a/docs/reference/classes/AsyncRateLimiter.md
+++ b/docs/reference/classes/AsyncRateLimiter.md
@@ -3,6 +3,8 @@ id: AsyncRateLimiter
 title: AsyncRateLimiter
 ---
 
+# Class: AsyncRateLimiter\<TFn\>
+
 Defined in: [async-rate-limiter.ts:245](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/async-rate-limiter.ts#L245)
 
 A class that creates an async rate-limited function.

--- a/docs/reference/classes/AsyncRateLimiter.md
+++ b/docs/reference/classes/AsyncRateLimiter.md
@@ -3,8 +3,6 @@ id: AsyncRateLimiter
 title: AsyncRateLimiter
 ---
 
-# Class: AsyncRateLimiter\<TFn\>
-
 Defined in: [async-rate-limiter.ts:245](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/async-rate-limiter.ts#L245)
 
 A class that creates an async rate-limited function.

--- a/docs/reference/classes/AsyncRetryer.md
+++ b/docs/reference/classes/AsyncRetryer.md
@@ -3,6 +3,8 @@ id: AsyncRetryer
 title: AsyncRetryer
 ---
 
+# Class: AsyncRetryer\<TFn\>
+
 Defined in: [async-retryer.ts:298](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/async-retryer.ts#L298)
 
 Provides robust retry functionality for asynchronous functions, supporting configurable backoff strategies,

--- a/docs/reference/classes/AsyncRetryer.md
+++ b/docs/reference/classes/AsyncRetryer.md
@@ -3,8 +3,6 @@ id: AsyncRetryer
 title: AsyncRetryer
 ---
 
-# Class: AsyncRetryer\<TFn\>
-
 Defined in: [async-retryer.ts:298](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/async-retryer.ts#L298)
 
 Provides robust retry functionality for asynchronous functions, supporting configurable backoff strategies,

--- a/docs/reference/classes/AsyncThrottler.md
+++ b/docs/reference/classes/AsyncThrottler.md
@@ -3,8 +3,6 @@ id: AsyncThrottler
 title: AsyncThrottler
 ---
 
-# Class: AsyncThrottler\<TFn\>
-
 Defined in: [async-throttler.ts:230](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/async-throttler.ts#L230)
 
 A class that creates an async throttled function.

--- a/docs/reference/classes/AsyncThrottler.md
+++ b/docs/reference/classes/AsyncThrottler.md
@@ -3,6 +3,8 @@ id: AsyncThrottler
 title: AsyncThrottler
 ---
 
+# Class: AsyncThrottler\<TFn\>
+
 Defined in: [async-throttler.ts:230](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/async-throttler.ts#L230)
 
 A class that creates an async throttled function.

--- a/docs/reference/classes/Batcher.md
+++ b/docs/reference/classes/Batcher.md
@@ -3,8 +3,6 @@ id: Batcher
 title: Batcher
 ---
 
-# Class: Batcher\<TValue\>
-
 Defined in: [batcher.ts:145](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/batcher.ts#L145)
 
 A class that collects items and processes them in batches.

--- a/docs/reference/classes/Batcher.md
+++ b/docs/reference/classes/Batcher.md
@@ -3,6 +3,8 @@ id: Batcher
 title: Batcher
 ---
 
+# Class: Batcher\<TValue\>
+
 Defined in: [batcher.ts:145](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/batcher.ts#L145)
 
 A class that collects items and processes them in batches.

--- a/docs/reference/classes/Debouncer.md
+++ b/docs/reference/classes/Debouncer.md
@@ -3,6 +3,8 @@ id: Debouncer
 title: Debouncer
 ---
 
+# Class: Debouncer\<TFn\>
+
 Defined in: [debouncer.ts:142](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/debouncer.ts#L142)
 
 A class that creates a debounced function.

--- a/docs/reference/classes/Debouncer.md
+++ b/docs/reference/classes/Debouncer.md
@@ -3,8 +3,6 @@ id: Debouncer
 title: Debouncer
 ---
 
-# Class: Debouncer\<TFn\>
-
 Defined in: [debouncer.ts:142](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/debouncer.ts#L142)
 
 A class that creates a debounced function.

--- a/docs/reference/classes/Queuer.md
+++ b/docs/reference/classes/Queuer.md
@@ -3,8 +3,6 @@ id: Queuer
 title: Queuer
 ---
 
-# Class: Queuer\<TValue\>
-
 Defined in: [queuer.ts:269](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/queuer.ts#L269)
 
 A flexible queue that processes items with configurable wait times, expiration, and priority.

--- a/docs/reference/classes/Queuer.md
+++ b/docs/reference/classes/Queuer.md
@@ -3,6 +3,8 @@ id: Queuer
 title: Queuer
 ---
 
+# Class: Queuer\<TValue\>
+
 Defined in: [queuer.ts:269](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/queuer.ts#L269)
 
 A flexible queue that processes items with configurable wait times, expiration, and priority.

--- a/docs/reference/classes/RateLimiter.md
+++ b/docs/reference/classes/RateLimiter.md
@@ -3,8 +3,6 @@ id: RateLimiter
 title: RateLimiter
 ---
 
-# Class: RateLimiter\<TFn\>
-
 Defined in: [rate-limiter.ts:156](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/rate-limiter.ts#L156)
 
 A class that creates a rate-limited function.

--- a/docs/reference/classes/RateLimiter.md
+++ b/docs/reference/classes/RateLimiter.md
@@ -3,6 +3,8 @@ id: RateLimiter
 title: RateLimiter
 ---
 
+# Class: RateLimiter\<TFn\>
+
 Defined in: [rate-limiter.ts:156](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/rate-limiter.ts#L156)
 
 A class that creates a rate-limited function.

--- a/docs/reference/classes/Throttler.md
+++ b/docs/reference/classes/Throttler.md
@@ -3,8 +3,6 @@ id: Throttler
 title: Throttler
 ---
 
-# Class: Throttler\<TFn\>
-
 Defined in: [throttler.ts:150](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/throttler.ts#L150)
 
 A class that creates a throttled function.

--- a/docs/reference/classes/Throttler.md
+++ b/docs/reference/classes/Throttler.md
@@ -3,6 +3,8 @@ id: Throttler
 title: Throttler
 ---
 
+# Class: Throttler\<TFn\>
+
 Defined in: [throttler.ts:150](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/throttler.ts#L150)
 
 A class that creates a throttled function.

--- a/docs/reference/functions/asyncBatch.md
+++ b/docs/reference/functions/asyncBatch.md
@@ -3,8 +3,6 @@ id: asyncBatch
 title: asyncBatch
 ---
 
-# Function: asyncBatch()
-
 ```ts
 function asyncBatch<TValue>(fn, options): (item) => Promise<any>;
 ```

--- a/docs/reference/functions/asyncBatch.md
+++ b/docs/reference/functions/asyncBatch.md
@@ -3,6 +3,8 @@ id: asyncBatch
 title: asyncBatch
 ---
 
+# Function: asyncBatch()
+
 ```ts
 function asyncBatch<TValue>(fn, options): (item) => Promise<any>;
 ```

--- a/docs/reference/functions/asyncBatcherOptions.md
+++ b/docs/reference/functions/asyncBatcherOptions.md
@@ -3,6 +3,8 @@ id: asyncBatcherOptions
 title: asyncBatcherOptions
 ---
 
+# Function: asyncBatcherOptions()
+
 ```ts
 function asyncBatcherOptions<TValue, TOptions>(options): TOptions;
 ```

--- a/docs/reference/functions/asyncBatcherOptions.md
+++ b/docs/reference/functions/asyncBatcherOptions.md
@@ -3,8 +3,6 @@ id: asyncBatcherOptions
 title: asyncBatcherOptions
 ---
 
-# Function: asyncBatcherOptions()
-
 ```ts
 function asyncBatcherOptions<TValue, TOptions>(options): TOptions;
 ```

--- a/docs/reference/functions/asyncDebounce.md
+++ b/docs/reference/functions/asyncDebounce.md
@@ -3,6 +3,8 @@ id: asyncDebounce
 title: asyncDebounce
 ---
 
+# Function: asyncDebounce()
+
 ```ts
 function asyncDebounce<TFn>(fn, initialOptions): (...args) => Promise<Awaited<ReturnType<TFn>> | undefined>;
 ```

--- a/docs/reference/functions/asyncDebounce.md
+++ b/docs/reference/functions/asyncDebounce.md
@@ -3,8 +3,6 @@ id: asyncDebounce
 title: asyncDebounce
 ---
 
-# Function: asyncDebounce()
-
 ```ts
 function asyncDebounce<TFn>(fn, initialOptions): (...args) => Promise<Awaited<ReturnType<TFn>> | undefined>;
 ```

--- a/docs/reference/functions/asyncDebouncerOptions.md
+++ b/docs/reference/functions/asyncDebouncerOptions.md
@@ -3,6 +3,8 @@ id: asyncDebouncerOptions
 title: asyncDebouncerOptions
 ---
 
+# Function: asyncDebouncerOptions()
+
 ```ts
 function asyncDebouncerOptions<TFn, TOptions>(options): TOptions;
 ```

--- a/docs/reference/functions/asyncDebouncerOptions.md
+++ b/docs/reference/functions/asyncDebouncerOptions.md
@@ -3,8 +3,6 @@ id: asyncDebouncerOptions
 title: asyncDebouncerOptions
 ---
 
-# Function: asyncDebouncerOptions()
-
 ```ts
 function asyncDebouncerOptions<TFn, TOptions>(options): TOptions;
 ```

--- a/docs/reference/functions/asyncQueue.md
+++ b/docs/reference/functions/asyncQueue.md
@@ -3,6 +3,8 @@ id: asyncQueue
 title: asyncQueue
 ---
 
+# Function: asyncQueue()
+
 ```ts
 function asyncQueue<TValue>(fn, initialOptions): (item, position, runOnItemsChange) => boolean;
 ```

--- a/docs/reference/functions/asyncQueue.md
+++ b/docs/reference/functions/asyncQueue.md
@@ -3,8 +3,6 @@ id: asyncQueue
 title: asyncQueue
 ---
 
-# Function: asyncQueue()
-
 ```ts
 function asyncQueue<TValue>(fn, initialOptions): (item, position, runOnItemsChange) => boolean;
 ```

--- a/docs/reference/functions/asyncQueuerOptions.md
+++ b/docs/reference/functions/asyncQueuerOptions.md
@@ -3,6 +3,8 @@ id: asyncQueuerOptions
 title: asyncQueuerOptions
 ---
 
+# Function: asyncQueuerOptions()
+
 ```ts
 function asyncQueuerOptions<TValue, TOptions>(options): TOptions;
 ```

--- a/docs/reference/functions/asyncQueuerOptions.md
+++ b/docs/reference/functions/asyncQueuerOptions.md
@@ -3,8 +3,6 @@ id: asyncQueuerOptions
 title: asyncQueuerOptions
 ---
 
-# Function: asyncQueuerOptions()
-
 ```ts
 function asyncQueuerOptions<TValue, TOptions>(options): TOptions;
 ```

--- a/docs/reference/functions/asyncRateLimit.md
+++ b/docs/reference/functions/asyncRateLimit.md
@@ -3,8 +3,6 @@ id: asyncRateLimit
 title: asyncRateLimit
 ---
 
-# Function: asyncRateLimit()
-
 ```ts
 function asyncRateLimit<TFn>(fn, initialOptions): (...args) => Promise<Awaited<ReturnType<TFn>> | undefined>;
 ```

--- a/docs/reference/functions/asyncRateLimit.md
+++ b/docs/reference/functions/asyncRateLimit.md
@@ -3,6 +3,8 @@ id: asyncRateLimit
 title: asyncRateLimit
 ---
 
+# Function: asyncRateLimit()
+
 ```ts
 function asyncRateLimit<TFn>(fn, initialOptions): (...args) => Promise<Awaited<ReturnType<TFn>> | undefined>;
 ```

--- a/docs/reference/functions/asyncRateLimiterOptions.md
+++ b/docs/reference/functions/asyncRateLimiterOptions.md
@@ -3,6 +3,8 @@ id: asyncRateLimiterOptions
 title: asyncRateLimiterOptions
 ---
 
+# Function: asyncRateLimiterOptions()
+
 ```ts
 function asyncRateLimiterOptions<TFn, TOptions>(options): TOptions;
 ```

--- a/docs/reference/functions/asyncRateLimiterOptions.md
+++ b/docs/reference/functions/asyncRateLimiterOptions.md
@@ -3,8 +3,6 @@ id: asyncRateLimiterOptions
 title: asyncRateLimiterOptions
 ---
 
-# Function: asyncRateLimiterOptions()
-
 ```ts
 function asyncRateLimiterOptions<TFn, TOptions>(options): TOptions;
 ```

--- a/docs/reference/functions/asyncRetry.md
+++ b/docs/reference/functions/asyncRetry.md
@@ -3,6 +3,8 @@ id: asyncRetry
 title: asyncRetry
 ---
 
+# Function: asyncRetry()
+
 ```ts
 function asyncRetry<TFn>(fn, initialOptions): (...args) => Promise<Awaited<ReturnType<TFn>> | undefined>;
 ```

--- a/docs/reference/functions/asyncRetry.md
+++ b/docs/reference/functions/asyncRetry.md
@@ -3,8 +3,6 @@ id: asyncRetry
 title: asyncRetry
 ---
 
-# Function: asyncRetry()
-
 ```ts
 function asyncRetry<TFn>(fn, initialOptions): (...args) => Promise<Awaited<ReturnType<TFn>> | undefined>;
 ```

--- a/docs/reference/functions/asyncRetryerOptions.md
+++ b/docs/reference/functions/asyncRetryerOptions.md
@@ -3,8 +3,6 @@ id: asyncRetryerOptions
 title: asyncRetryerOptions
 ---
 
-# Function: asyncRetryerOptions()
-
 ```ts
 function asyncRetryerOptions<TFn, TOptions>(options): TOptions;
 ```

--- a/docs/reference/functions/asyncRetryerOptions.md
+++ b/docs/reference/functions/asyncRetryerOptions.md
@@ -3,6 +3,8 @@ id: asyncRetryerOptions
 title: asyncRetryerOptions
 ---
 
+# Function: asyncRetryerOptions()
+
 ```ts
 function asyncRetryerOptions<TFn, TOptions>(options): TOptions;
 ```

--- a/docs/reference/functions/asyncThrottle.md
+++ b/docs/reference/functions/asyncThrottle.md
@@ -3,6 +3,8 @@ id: asyncThrottle
 title: asyncThrottle
 ---
 
+# Function: asyncThrottle()
+
 ```ts
 function asyncThrottle<TFn>(fn, initialOptions): (...args) => Promise<Awaited<ReturnType<TFn>> | undefined>;
 ```

--- a/docs/reference/functions/asyncThrottle.md
+++ b/docs/reference/functions/asyncThrottle.md
@@ -3,8 +3,6 @@ id: asyncThrottle
 title: asyncThrottle
 ---
 
-# Function: asyncThrottle()
-
 ```ts
 function asyncThrottle<TFn>(fn, initialOptions): (...args) => Promise<Awaited<ReturnType<TFn>> | undefined>;
 ```

--- a/docs/reference/functions/asyncThrottlerOptions.md
+++ b/docs/reference/functions/asyncThrottlerOptions.md
@@ -3,8 +3,6 @@ id: asyncThrottlerOptions
 title: asyncThrottlerOptions
 ---
 
-# Function: asyncThrottlerOptions()
-
 ```ts
 function asyncThrottlerOptions<TFn, TOptions>(options): TOptions;
 ```

--- a/docs/reference/functions/asyncThrottlerOptions.md
+++ b/docs/reference/functions/asyncThrottlerOptions.md
@@ -3,6 +3,8 @@ id: asyncThrottlerOptions
 title: asyncThrottlerOptions
 ---
 
+# Function: asyncThrottlerOptions()
+
 ```ts
 function asyncThrottlerOptions<TFn, TOptions>(options): TOptions;
 ```

--- a/docs/reference/functions/batch.md
+++ b/docs/reference/functions/batch.md
@@ -3,8 +3,6 @@ id: batch
 title: batch
 ---
 
-# Function: batch()
-
 ```ts
 function batch<TValue>(fn, options): (item) => void;
 ```

--- a/docs/reference/functions/batch.md
+++ b/docs/reference/functions/batch.md
@@ -3,6 +3,8 @@ id: batch
 title: batch
 ---
 
+# Function: batch()
+
 ```ts
 function batch<TValue>(fn, options): (item) => void;
 ```

--- a/docs/reference/functions/debounce.md
+++ b/docs/reference/functions/debounce.md
@@ -3,8 +3,6 @@ id: debounce
 title: debounce
 ---
 
-# Function: debounce()
-
 ```ts
 function debounce<TFn>(fn, initialOptions): (...args) => void;
 ```

--- a/docs/reference/functions/debounce.md
+++ b/docs/reference/functions/debounce.md
@@ -3,6 +3,8 @@ id: debounce
 title: debounce
 ---
 
+# Function: debounce()
+
 ```ts
 function debounce<TFn>(fn, initialOptions): (...args) => void;
 ```

--- a/docs/reference/functions/debouncerOptions.md
+++ b/docs/reference/functions/debouncerOptions.md
@@ -3,8 +3,6 @@ id: debouncerOptions
 title: debouncerOptions
 ---
 
-# Function: debouncerOptions()
-
 ```ts
 function debouncerOptions<TFn, TOptions>(options): TOptions;
 ```

--- a/docs/reference/functions/debouncerOptions.md
+++ b/docs/reference/functions/debouncerOptions.md
@@ -3,6 +3,8 @@ id: debouncerOptions
 title: debouncerOptions
 ---
 
+# Function: debouncerOptions()
+
 ```ts
 function debouncerOptions<TFn, TOptions>(options): TOptions;
 ```

--- a/docs/reference/functions/emitChange.md
+++ b/docs/reference/functions/emitChange.md
@@ -3,6 +3,8 @@ id: emitChange
 title: emitChange
 ---
 
+# Function: emitChange()
+
 ```ts
 function emitChange<TEvent>(event, instance): void;
 ```

--- a/docs/reference/functions/emitChange.md
+++ b/docs/reference/functions/emitChange.md
@@ -3,8 +3,6 @@ id: emitChange
 title: emitChange
 ---
 
-# Function: emitChange()
-
 ```ts
 function emitChange<TEvent>(event, instance): void;
 ```

--- a/docs/reference/functions/getPacerDevtoolsInstance.md
+++ b/docs/reference/functions/getPacerDevtoolsInstance.md
@@ -3,8 +3,6 @@ id: getPacerDevtoolsInstance
 title: getPacerDevtoolsInstance
 ---
 
-# Function: getPacerDevtoolsInstance()
-
 ```ts
 function getPacerDevtoolsInstance(key): unknown;
 ```

--- a/docs/reference/functions/getPacerDevtoolsInstance.md
+++ b/docs/reference/functions/getPacerDevtoolsInstance.md
@@ -3,6 +3,8 @@ id: getPacerDevtoolsInstance
 title: getPacerDevtoolsInstance
 ---
 
+# Function: getPacerDevtoolsInstance()
+
 ```ts
 function getPacerDevtoolsInstance(key): unknown;
 ```

--- a/docs/reference/functions/isFunction.md
+++ b/docs/reference/functions/isFunction.md
@@ -3,8 +3,6 @@ id: isFunction
 title: isFunction
 ---
 
-# Function: isFunction()
-
 ```ts
 function isFunction<T>(value): value is T;
 ```

--- a/docs/reference/functions/isFunction.md
+++ b/docs/reference/functions/isFunction.md
@@ -3,6 +3,8 @@ id: isFunction
 title: isFunction
 ---
 
+# Function: isFunction()
+
 ```ts
 function isFunction<T>(value): value is T;
 ```

--- a/docs/reference/functions/parseFunctionOrValue.md
+++ b/docs/reference/functions/parseFunctionOrValue.md
@@ -3,6 +3,8 @@ id: parseFunctionOrValue
 title: parseFunctionOrValue
 ---
 
+# Function: parseFunctionOrValue()
+
 ```ts
 function parseFunctionOrValue<T, TArgs>(value, ...args): T;
 ```

--- a/docs/reference/functions/parseFunctionOrValue.md
+++ b/docs/reference/functions/parseFunctionOrValue.md
@@ -3,8 +3,6 @@ id: parseFunctionOrValue
 title: parseFunctionOrValue
 ---
 
-# Function: parseFunctionOrValue()
-
 ```ts
 function parseFunctionOrValue<T, TArgs>(value, ...args): T;
 ```

--- a/docs/reference/functions/queue.md
+++ b/docs/reference/functions/queue.md
@@ -3,6 +3,8 @@ id: queue
 title: queue
 ---
 
+# Function: queue()
+
 ```ts
 function queue<TValue>(fn, initialOptions): (item, position, runOnItemsChange) => boolean;
 ```

--- a/docs/reference/functions/queue.md
+++ b/docs/reference/functions/queue.md
@@ -3,8 +3,6 @@ id: queue
 title: queue
 ---
 
-# Function: queue()
-
 ```ts
 function queue<TValue>(fn, initialOptions): (item, position, runOnItemsChange) => boolean;
 ```

--- a/docs/reference/functions/queuerOptions.md
+++ b/docs/reference/functions/queuerOptions.md
@@ -3,6 +3,8 @@ id: queuerOptions
 title: queuerOptions
 ---
 
+# Function: queuerOptions()
+
 ```ts
 function queuerOptions<TValue, TOptions>(options): TOptions;
 ```

--- a/docs/reference/functions/queuerOptions.md
+++ b/docs/reference/functions/queuerOptions.md
@@ -3,8 +3,6 @@ id: queuerOptions
 title: queuerOptions
 ---
 
-# Function: queuerOptions()
-
 ```ts
 function queuerOptions<TValue, TOptions>(options): TOptions;
 ```

--- a/docs/reference/functions/rateLimit.md
+++ b/docs/reference/functions/rateLimit.md
@@ -3,8 +3,6 @@ id: rateLimit
 title: rateLimit
 ---
 
-# Function: rateLimit()
-
 ```ts
 function rateLimit<TFn>(fn, initialOptions): (...args) => boolean;
 ```

--- a/docs/reference/functions/rateLimit.md
+++ b/docs/reference/functions/rateLimit.md
@@ -3,6 +3,8 @@ id: rateLimit
 title: rateLimit
 ---
 
+# Function: rateLimit()
+
 ```ts
 function rateLimit<TFn>(fn, initialOptions): (...args) => boolean;
 ```

--- a/docs/reference/functions/rateLimiterOptions.md
+++ b/docs/reference/functions/rateLimiterOptions.md
@@ -3,8 +3,6 @@ id: rateLimiterOptions
 title: rateLimiterOptions
 ---
 
-# Function: rateLimiterOptions()
-
 ```ts
 function rateLimiterOptions<TFn, TOptions>(options): TOptions;
 ```

--- a/docs/reference/functions/rateLimiterOptions.md
+++ b/docs/reference/functions/rateLimiterOptions.md
@@ -3,6 +3,8 @@ id: rateLimiterOptions
 title: rateLimiterOptions
 ---
 
+# Function: rateLimiterOptions()
+
 ```ts
 function rateLimiterOptions<TFn, TOptions>(options): TOptions;
 ```

--- a/docs/reference/functions/throttle.md
+++ b/docs/reference/functions/throttle.md
@@ -3,8 +3,6 @@ id: throttle
 title: throttle
 ---
 
-# Function: throttle()
-
 ```ts
 function throttle<TFn>(fn, initialOptions): (...args) => void;
 ```

--- a/docs/reference/functions/throttle.md
+++ b/docs/reference/functions/throttle.md
@@ -3,6 +3,8 @@ id: throttle
 title: throttle
 ---
 
+# Function: throttle()
+
 ```ts
 function throttle<TFn>(fn, initialOptions): (...args) => void;
 ```

--- a/docs/reference/functions/throttlerOptions.md
+++ b/docs/reference/functions/throttlerOptions.md
@@ -3,6 +3,8 @@ id: throttlerOptions
 title: throttlerOptions
 ---
 
+# Function: throttlerOptions()
+
 ```ts
 function throttlerOptions<TFn, TOptions>(options): TOptions;
 ```

--- a/docs/reference/functions/throttlerOptions.md
+++ b/docs/reference/functions/throttlerOptions.md
@@ -3,8 +3,6 @@ id: throttlerOptions
 title: throttlerOptions
 ---
 
-# Function: throttlerOptions()
-
 ```ts
 function throttlerOptions<TFn, TOptions>(options): TOptions;
 ```

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -3,6 +3,8 @@ id: "@tanstack/pacer"
 title: "@tanstack/pacer"
 ---
 
+# @tanstack/pacer
+
 ## Classes
 
 - [AsyncBatcher](classes/AsyncBatcher.md)

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -3,8 +3,6 @@ id: "@tanstack/pacer"
 title: "@tanstack/pacer"
 ---
 
-# @tanstack/pacer
-
 ## Classes
 
 - [AsyncBatcher](classes/AsyncBatcher.md)

--- a/docs/reference/interfaces/AsyncBatcherOptions.md
+++ b/docs/reference/interfaces/AsyncBatcherOptions.md
@@ -3,8 +3,6 @@ id: AsyncBatcherOptions
 title: AsyncBatcherOptions
 ---
 
-# Interface: AsyncBatcherOptions\<TValue\>
-
 Defined in: [async-batcher.ts:89](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/async-batcher.ts#L89)
 
 Options for configuring an AsyncBatcher instance

--- a/docs/reference/interfaces/AsyncBatcherOptions.md
+++ b/docs/reference/interfaces/AsyncBatcherOptions.md
@@ -3,6 +3,8 @@ id: AsyncBatcherOptions
 title: AsyncBatcherOptions
 ---
 
+# Interface: AsyncBatcherOptions\<TValue\>
+
 Defined in: [async-batcher.ts:89](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/async-batcher.ts#L89)
 
 Options for configuring an AsyncBatcher instance

--- a/docs/reference/interfaces/AsyncBatcherState.md
+++ b/docs/reference/interfaces/AsyncBatcherState.md
@@ -3,6 +3,8 @@ id: AsyncBatcherState
 title: AsyncBatcherState
 ---
 
+# Interface: AsyncBatcherState\<TValue\>
+
 Defined in: [async-batcher.ts:8](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/async-batcher.ts#L8)
 
 ## Type Parameters

--- a/docs/reference/interfaces/AsyncBatcherState.md
+++ b/docs/reference/interfaces/AsyncBatcherState.md
@@ -3,8 +3,6 @@ id: AsyncBatcherState
 title: AsyncBatcherState
 ---
 
-# Interface: AsyncBatcherState\<TValue\>
-
 Defined in: [async-batcher.ts:8](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/async-batcher.ts#L8)
 
 ## Type Parameters

--- a/docs/reference/interfaces/AsyncDebouncerOptions.md
+++ b/docs/reference/interfaces/AsyncDebouncerOptions.md
@@ -3,8 +3,6 @@ id: AsyncDebouncerOptions
 title: AsyncDebouncerOptions
 ---
 
-# Interface: AsyncDebouncerOptions\<TFn\>
-
 Defined in: [async-debouncer.ts:71](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/async-debouncer.ts#L71)
 
 Options for configuring an async debounced function

--- a/docs/reference/interfaces/AsyncDebouncerOptions.md
+++ b/docs/reference/interfaces/AsyncDebouncerOptions.md
@@ -3,6 +3,8 @@ id: AsyncDebouncerOptions
 title: AsyncDebouncerOptions
 ---
 
+# Interface: AsyncDebouncerOptions\<TFn\>
+
 Defined in: [async-debouncer.ts:71](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/async-debouncer.ts#L71)
 
 Options for configuring an async debounced function

--- a/docs/reference/interfaces/AsyncDebouncerState.md
+++ b/docs/reference/interfaces/AsyncDebouncerState.md
@@ -3,8 +3,6 @@ id: AsyncDebouncerState
 title: AsyncDebouncerState
 ---
 
-# Interface: AsyncDebouncerState\<TFn\>
-
 Defined in: [async-debouncer.ts:8](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/async-debouncer.ts#L8)
 
 ## Type Parameters

--- a/docs/reference/interfaces/AsyncDebouncerState.md
+++ b/docs/reference/interfaces/AsyncDebouncerState.md
@@ -3,6 +3,8 @@ id: AsyncDebouncerState
 title: AsyncDebouncerState
 ---
 
+# Interface: AsyncDebouncerState\<TFn\>
+
 Defined in: [async-debouncer.ts:8](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/async-debouncer.ts#L8)
 
 ## Type Parameters

--- a/docs/reference/interfaces/AsyncQueuerOptions.md
+++ b/docs/reference/interfaces/AsyncQueuerOptions.md
@@ -3,8 +3,6 @@ id: AsyncQueuerOptions
 title: AsyncQueuerOptions
 ---
 
-# Interface: AsyncQueuerOptions\<TValue\>
-
 Defined in: [async-queuer.ts:112](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/async-queuer.ts#L112)
 
 ## Type Parameters

--- a/docs/reference/interfaces/AsyncQueuerOptions.md
+++ b/docs/reference/interfaces/AsyncQueuerOptions.md
@@ -3,6 +3,8 @@ id: AsyncQueuerOptions
 title: AsyncQueuerOptions
 ---
 
+# Interface: AsyncQueuerOptions\<TValue\>
+
 Defined in: [async-queuer.ts:112](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/async-queuer.ts#L112)
 
 ## Type Parameters

--- a/docs/reference/interfaces/AsyncQueuerState.md
+++ b/docs/reference/interfaces/AsyncQueuerState.md
@@ -3,8 +3,6 @@ id: AsyncQueuerState
 title: AsyncQueuerState
 ---
 
-# Interface: AsyncQueuerState\<TValue\>
-
 Defined in: [async-queuer.ts:9](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/async-queuer.ts#L9)
 
 ## Type Parameters

--- a/docs/reference/interfaces/AsyncQueuerState.md
+++ b/docs/reference/interfaces/AsyncQueuerState.md
@@ -3,6 +3,8 @@ id: AsyncQueuerState
 title: AsyncQueuerState
 ---
 
+# Interface: AsyncQueuerState\<TValue\>
+
 Defined in: [async-queuer.ts:9](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/async-queuer.ts#L9)
 
 ## Type Parameters

--- a/docs/reference/interfaces/AsyncRateLimiterOptions.md
+++ b/docs/reference/interfaces/AsyncRateLimiterOptions.md
@@ -3,8 +3,6 @@ id: AsyncRateLimiterOptions
 title: AsyncRateLimiterOptions
 ---
 
-# Interface: AsyncRateLimiterOptions\<TFn\>
-
 Defined in: [async-rate-limiter.ts:71](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/async-rate-limiter.ts#L71)
 
 Options for configuring an async rate-limited function

--- a/docs/reference/interfaces/AsyncRateLimiterOptions.md
+++ b/docs/reference/interfaces/AsyncRateLimiterOptions.md
@@ -3,6 +3,8 @@ id: AsyncRateLimiterOptions
 title: AsyncRateLimiterOptions
 ---
 
+# Interface: AsyncRateLimiterOptions\<TFn\>
+
 Defined in: [async-rate-limiter.ts:71](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/async-rate-limiter.ts#L71)
 
 Options for configuring an async rate-limited function

--- a/docs/reference/interfaces/AsyncRateLimiterState.md
+++ b/docs/reference/interfaces/AsyncRateLimiterState.md
@@ -3,6 +3,8 @@ id: AsyncRateLimiterState
 title: AsyncRateLimiterState
 ---
 
+# Interface: AsyncRateLimiterState\<TFn\>
+
 Defined in: [async-rate-limiter.ts:8](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/async-rate-limiter.ts#L8)
 
 ## Type Parameters

--- a/docs/reference/interfaces/AsyncRateLimiterState.md
+++ b/docs/reference/interfaces/AsyncRateLimiterState.md
@@ -3,8 +3,6 @@ id: AsyncRateLimiterState
 title: AsyncRateLimiterState
 ---
 
-# Interface: AsyncRateLimiterState\<TFn\>
-
 Defined in: [async-rate-limiter.ts:8](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/async-rate-limiter.ts#L8)
 
 ## Type Parameters

--- a/docs/reference/interfaces/AsyncRetryerOptions.md
+++ b/docs/reference/interfaces/AsyncRetryerOptions.md
@@ -3,6 +3,8 @@ id: AsyncRetryerOptions
 title: AsyncRetryerOptions
 ---
 
+# Interface: AsyncRetryerOptions\<TFn\>
+
 Defined in: [async-retryer.ts:59](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/async-retryer.ts#L59)
 
 ## Type Parameters

--- a/docs/reference/interfaces/AsyncRetryerOptions.md
+++ b/docs/reference/interfaces/AsyncRetryerOptions.md
@@ -3,8 +3,6 @@ id: AsyncRetryerOptions
 title: AsyncRetryerOptions
 ---
 
-# Interface: AsyncRetryerOptions\<TFn\>
-
 Defined in: [async-retryer.ts:59](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/async-retryer.ts#L59)
 
 ## Type Parameters

--- a/docs/reference/interfaces/AsyncRetryerState.md
+++ b/docs/reference/interfaces/AsyncRetryerState.md
@@ -3,8 +3,6 @@ id: AsyncRetryerState
 title: AsyncRetryerState
 ---
 
-# Interface: AsyncRetryerState\<TFn\>
-
 Defined in: [async-retryer.ts:5](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/async-retryer.ts#L5)
 
 ## Type Parameters

--- a/docs/reference/interfaces/AsyncRetryerState.md
+++ b/docs/reference/interfaces/AsyncRetryerState.md
@@ -3,6 +3,8 @@ id: AsyncRetryerState
 title: AsyncRetryerState
 ---
 
+# Interface: AsyncRetryerState\<TFn\>
+
 Defined in: [async-retryer.ts:5](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/async-retryer.ts#L5)
 
 ## Type Parameters

--- a/docs/reference/interfaces/AsyncThrottlerOptions.md
+++ b/docs/reference/interfaces/AsyncThrottlerOptions.md
@@ -3,8 +3,6 @@ id: AsyncThrottlerOptions
 title: AsyncThrottlerOptions
 ---
 
-# Interface: AsyncThrottlerOptions\<TFn\>
-
 Defined in: [async-throttler.ts:76](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/async-throttler.ts#L76)
 
 Options for configuring an async throttled function

--- a/docs/reference/interfaces/AsyncThrottlerOptions.md
+++ b/docs/reference/interfaces/AsyncThrottlerOptions.md
@@ -3,6 +3,8 @@ id: AsyncThrottlerOptions
 title: AsyncThrottlerOptions
 ---
 
+# Interface: AsyncThrottlerOptions\<TFn\>
+
 Defined in: [async-throttler.ts:76](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/async-throttler.ts#L76)
 
 Options for configuring an async throttled function

--- a/docs/reference/interfaces/AsyncThrottlerState.md
+++ b/docs/reference/interfaces/AsyncThrottlerState.md
@@ -3,6 +3,8 @@ id: AsyncThrottlerState
 title: AsyncThrottlerState
 ---
 
+# Interface: AsyncThrottlerState\<TFn\>
+
 Defined in: [async-throttler.ts:8](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/async-throttler.ts#L8)
 
 ## Type Parameters

--- a/docs/reference/interfaces/AsyncThrottlerState.md
+++ b/docs/reference/interfaces/AsyncThrottlerState.md
@@ -3,8 +3,6 @@ id: AsyncThrottlerState
 title: AsyncThrottlerState
 ---
 
-# Interface: AsyncThrottlerState\<TFn\>
-
 Defined in: [async-throttler.ts:8](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/async-throttler.ts#L8)
 
 ## Type Parameters

--- a/docs/reference/interfaces/BatcherOptions.md
+++ b/docs/reference/interfaces/BatcherOptions.md
@@ -3,8 +3,6 @@ id: BatcherOptions
 title: BatcherOptions
 ---
 
-# Interface: BatcherOptions\<TValue\>
-
 Defined in: [batcher.ts:52](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/batcher.ts#L52)
 
 Options for configuring a Batcher instance

--- a/docs/reference/interfaces/BatcherOptions.md
+++ b/docs/reference/interfaces/BatcherOptions.md
@@ -3,6 +3,8 @@ id: BatcherOptions
 title: BatcherOptions
 ---
 
+# Interface: BatcherOptions\<TValue\>
+
 Defined in: [batcher.ts:52](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/batcher.ts#L52)
 
 Options for configuring a Batcher instance

--- a/docs/reference/interfaces/BatcherState.md
+++ b/docs/reference/interfaces/BatcherState.md
@@ -3,6 +3,8 @@ id: BatcherState
 title: BatcherState
 ---
 
+# Interface: BatcherState\<TValue\>
+
 Defined in: [batcher.ts:6](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/batcher.ts#L6)
 
 ## Type Parameters

--- a/docs/reference/interfaces/BatcherState.md
+++ b/docs/reference/interfaces/BatcherState.md
@@ -3,8 +3,6 @@ id: BatcherState
 title: BatcherState
 ---
 
-# Interface: BatcherState\<TValue\>
-
 Defined in: [batcher.ts:6](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/batcher.ts#L6)
 
 ## Type Parameters

--- a/docs/reference/interfaces/DebouncerOptions.md
+++ b/docs/reference/interfaces/DebouncerOptions.md
@@ -3,8 +3,6 @@ id: DebouncerOptions
 title: DebouncerOptions
 ---
 
-# Interface: DebouncerOptions\<TFn\>
-
 Defined in: [debouncer.ts:49](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/debouncer.ts#L49)
 
 Options for configuring a debounced function

--- a/docs/reference/interfaces/DebouncerOptions.md
+++ b/docs/reference/interfaces/DebouncerOptions.md
@@ -3,6 +3,8 @@ id: DebouncerOptions
 title: DebouncerOptions
 ---
 
+# Interface: DebouncerOptions\<TFn\>
+
 Defined in: [debouncer.ts:49](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/debouncer.ts#L49)
 
 Options for configuring a debounced function

--- a/docs/reference/interfaces/DebouncerState.md
+++ b/docs/reference/interfaces/DebouncerState.md
@@ -3,8 +3,6 @@ id: DebouncerState
 title: DebouncerState
 ---
 
-# Interface: DebouncerState\<TFn\>
-
 Defined in: [debouncer.ts:6](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/debouncer.ts#L6)
 
 ## Type Parameters

--- a/docs/reference/interfaces/DebouncerState.md
+++ b/docs/reference/interfaces/DebouncerState.md
@@ -3,6 +3,8 @@ id: DebouncerState
 title: DebouncerState
 ---
 
+# Interface: DebouncerState\<TFn\>
+
 Defined in: [debouncer.ts:6](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/debouncer.ts#L6)
 
 ## Type Parameters

--- a/docs/reference/interfaces/PacerDevtoolsWirePayload.md
+++ b/docs/reference/interfaces/PacerDevtoolsWirePayload.md
@@ -3,8 +3,6 @@ id: PacerDevtoolsWirePayload
 title: PacerDevtoolsWirePayload
 ---
 
-# Interface: PacerDevtoolsWirePayload
-
 Defined in: [event-client.ts:10](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/event-client.ts#L10)
 
 Payload on the devtools event bus must be JSON-serializable: `ClientEventBus`

--- a/docs/reference/interfaces/PacerDevtoolsWirePayload.md
+++ b/docs/reference/interfaces/PacerDevtoolsWirePayload.md
@@ -3,6 +3,8 @@ id: PacerDevtoolsWirePayload
 title: PacerDevtoolsWirePayload
 ---
 
+# Interface: PacerDevtoolsWirePayload
+
 Defined in: [event-client.ts:10](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/event-client.ts#L10)
 
 Payload on the devtools event bus must be JSON-serializable: `ClientEventBus`

--- a/docs/reference/interfaces/PacerEventMap.md
+++ b/docs/reference/interfaces/PacerEventMap.md
@@ -3,6 +3,8 @@ id: PacerEventMap
 title: PacerEventMap
 ---
 
+# Interface: PacerEventMap
+
 Defined in: [event-client.ts:66](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/event-client.ts#L66)
 
 Suffix-only keys: EventClient prepends `pluginId:` (`pacer:`) at runtime

--- a/docs/reference/interfaces/PacerEventMap.md
+++ b/docs/reference/interfaces/PacerEventMap.md
@@ -3,8 +3,6 @@ id: PacerEventMap
 title: PacerEventMap
 ---
 
-# Interface: PacerEventMap
-
 Defined in: [event-client.ts:66](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/event-client.ts#L66)
 
 Suffix-only keys: EventClient prepends `pluginId:` (`pacer:`) at runtime

--- a/docs/reference/interfaces/QueuerOptions.md
+++ b/docs/reference/interfaces/QueuerOptions.md
@@ -3,8 +3,6 @@ id: QueuerOptions
 title: QueuerOptions
 ---
 
-# Interface: QueuerOptions\<TValue\>
-
 Defined in: [queuer.ts:83](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/queuer.ts#L83)
 
 Options for configuring a Queuer instance.

--- a/docs/reference/interfaces/QueuerOptions.md
+++ b/docs/reference/interfaces/QueuerOptions.md
@@ -3,6 +3,8 @@ id: QueuerOptions
 title: QueuerOptions
 ---
 
+# Interface: QueuerOptions\<TValue\>
+
 Defined in: [queuer.ts:83](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/queuer.ts#L83)
 
 Options for configuring a Queuer instance.

--- a/docs/reference/interfaces/QueuerState.md
+++ b/docs/reference/interfaces/QueuerState.md
@@ -3,6 +3,8 @@ id: QueuerState
 title: QueuerState
 ---
 
+# Interface: QueuerState\<TValue\>
+
 Defined in: [queuer.ts:5](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/queuer.ts#L5)
 
 ## Type Parameters

--- a/docs/reference/interfaces/QueuerState.md
+++ b/docs/reference/interfaces/QueuerState.md
@@ -3,8 +3,6 @@ id: QueuerState
 title: QueuerState
 ---
 
-# Interface: QueuerState\<TValue\>
-
 Defined in: [queuer.ts:5](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/queuer.ts#L5)
 
 ## Type Parameters

--- a/docs/reference/interfaces/RateLimiterOptions.md
+++ b/docs/reference/interfaces/RateLimiterOptions.md
@@ -3,8 +3,6 @@ id: RateLimiterOptions
 title: RateLimiterOptions
 ---
 
-# Interface: RateLimiterOptions\<TFn\>
-
 Defined in: [rate-limiter.ts:47](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/rate-limiter.ts#L47)
 
 Options for configuring a rate-limited function

--- a/docs/reference/interfaces/RateLimiterOptions.md
+++ b/docs/reference/interfaces/RateLimiterOptions.md
@@ -3,6 +3,8 @@ id: RateLimiterOptions
 title: RateLimiterOptions
 ---
 
+# Interface: RateLimiterOptions\<TFn\>
+
 Defined in: [rate-limiter.ts:47](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/rate-limiter.ts#L47)
 
 Options for configuring a rate-limited function

--- a/docs/reference/interfaces/RateLimiterState.md
+++ b/docs/reference/interfaces/RateLimiterState.md
@@ -3,6 +3,8 @@ id: RateLimiterState
 title: RateLimiterState
 ---
 
+# Interface: RateLimiterState
+
 Defined in: [rate-limiter.ts:6](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/rate-limiter.ts#L6)
 
 ## Properties

--- a/docs/reference/interfaces/RateLimiterState.md
+++ b/docs/reference/interfaces/RateLimiterState.md
@@ -3,8 +3,6 @@ id: RateLimiterState
 title: RateLimiterState
 ---
 
-# Interface: RateLimiterState
-
 Defined in: [rate-limiter.ts:6](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/rate-limiter.ts#L6)
 
 ## Properties

--- a/docs/reference/interfaces/ThrottlerOptions.md
+++ b/docs/reference/interfaces/ThrottlerOptions.md
@@ -3,6 +3,8 @@ id: ThrottlerOptions
 title: ThrottlerOptions
 ---
 
+# Interface: ThrottlerOptions\<TFn\>
+
 Defined in: [throttler.ts:54](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/throttler.ts#L54)
 
 Options for configuring a throttled function

--- a/docs/reference/interfaces/ThrottlerOptions.md
+++ b/docs/reference/interfaces/ThrottlerOptions.md
@@ -3,8 +3,6 @@ id: ThrottlerOptions
 title: ThrottlerOptions
 ---
 
-# Interface: ThrottlerOptions\<TFn\>
-
 Defined in: [throttler.ts:54](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/throttler.ts#L54)
 
 Options for configuring a throttled function

--- a/docs/reference/interfaces/ThrottlerState.md
+++ b/docs/reference/interfaces/ThrottlerState.md
@@ -3,6 +3,8 @@ id: ThrottlerState
 title: ThrottlerState
 ---
 
+# Interface: ThrottlerState\<TFn\>
+
 Defined in: [throttler.ts:6](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/throttler.ts#L6)
 
 ## Type Parameters

--- a/docs/reference/interfaces/ThrottlerState.md
+++ b/docs/reference/interfaces/ThrottlerState.md
@@ -3,8 +3,6 @@ id: ThrottlerState
 title: ThrottlerState
 ---
 
-# Interface: ThrottlerState\<TFn\>
-
 Defined in: [throttler.ts:6](https://github.com/TanStack/pacer/blob/main/packages/pacer/src/throttler.ts#L6)
 
 ## Type Parameters

--- a/docs/reference/type-aliases/AnyAsyncFunction.md
+++ b/docs/reference/type-aliases/AnyAsyncFunction.md
@@ -3,6 +3,8 @@ id: AnyAsyncFunction
 title: AnyAsyncFunction
 ---
 
+# Type Alias: AnyAsyncFunction()
+
 ```ts
 type AnyAsyncFunction = (...args) => Promise<any>;
 ```

--- a/docs/reference/type-aliases/AnyAsyncFunction.md
+++ b/docs/reference/type-aliases/AnyAsyncFunction.md
@@ -3,8 +3,6 @@ id: AnyAsyncFunction
 title: AnyAsyncFunction
 ---
 
-# Type Alias: AnyAsyncFunction()
-
 ```ts
 type AnyAsyncFunction = (...args) => Promise<any>;
 ```

--- a/docs/reference/type-aliases/AnyFunction.md
+++ b/docs/reference/type-aliases/AnyFunction.md
@@ -3,8 +3,6 @@ id: AnyFunction
 title: AnyFunction
 ---
 
-# Type Alias: AnyFunction()
-
 ```ts
 type AnyFunction = (...args) => any;
 ```

--- a/docs/reference/type-aliases/AnyFunction.md
+++ b/docs/reference/type-aliases/AnyFunction.md
@@ -3,6 +3,8 @@ id: AnyFunction
 title: AnyFunction
 ---
 
+# Type Alias: AnyFunction()
+
 ```ts
 type AnyFunction = (...args) => any;
 ```

--- a/docs/reference/type-aliases/OptionalKeys.md
+++ b/docs/reference/type-aliases/OptionalKeys.md
@@ -3,8 +3,6 @@ id: OptionalKeys
 title: OptionalKeys
 ---
 
-# Type Alias: OptionalKeys\<T, TKey\>
-
 ```ts
 type OptionalKeys<T, TKey> = Omit<T, TKey> & Partial<Pick<T, TKey>>;
 ```

--- a/docs/reference/type-aliases/OptionalKeys.md
+++ b/docs/reference/type-aliases/OptionalKeys.md
@@ -3,6 +3,8 @@ id: OptionalKeys
 title: OptionalKeys
 ---
 
+# Type Alias: OptionalKeys\<T, TKey\>
+
 ```ts
 type OptionalKeys<T, TKey> = Omit<T, TKey> & Partial<Pick<T, TKey>>;
 ```

--- a/docs/reference/type-aliases/PacerEventName.md
+++ b/docs/reference/type-aliases/PacerEventName.md
@@ -3,8 +3,6 @@ id: PacerEventName
 title: PacerEventName
 ---
 
-# Type Alias: PacerEventName
-
 ```ts
 type PacerEventName = keyof PacerEventMap;
 ```

--- a/docs/reference/type-aliases/PacerEventName.md
+++ b/docs/reference/type-aliases/PacerEventName.md
@@ -3,6 +3,8 @@ id: PacerEventName
 title: PacerEventName
 ---
 
+# Type Alias: PacerEventName
+
 ```ts
 type PacerEventName = keyof PacerEventMap;
 ```

--- a/docs/reference/type-aliases/QueuePosition.md
+++ b/docs/reference/type-aliases/QueuePosition.md
@@ -3,8 +3,6 @@ id: QueuePosition
 title: QueuePosition
 ---
 
-# Type Alias: QueuePosition
-
 ```ts
 type QueuePosition = "front" | "back";
 ```

--- a/docs/reference/type-aliases/QueuePosition.md
+++ b/docs/reference/type-aliases/QueuePosition.md
@@ -3,6 +3,8 @@ id: QueuePosition
 title: QueuePosition
 ---
 
+# Type Alias: QueuePosition
+
 ```ts
 type QueuePosition = "front" | "back";
 ```

--- a/docs/reference/variables/pacerEventClient.md
+++ b/docs/reference/variables/pacerEventClient.md
@@ -3,8 +3,6 @@ id: pacerEventClient
 title: pacerEventClient
 ---
 
-# Variable: pacerEventClient
-
 ```ts
 const pacerEventClient: PacerEventClient;
 ```

--- a/docs/reference/variables/pacerEventClient.md
+++ b/docs/reference/variables/pacerEventClient.md
@@ -3,6 +3,8 @@ id: pacerEventClient
 title: pacerEventClient
 ---
 
+# Variable: pacerEventClient
+
 ```ts
 const pacerEventClient: PacerEventClient;
 ```

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,3 @@
+{
+  "hidePageTitle": true
+}


### PR DESCRIPTION
## 🎯 Changes

Configure TypeDoc to omit page titles because tanstack.com renders the title from frontmatter.


## ✅ Checklist

- [ ] I have followed the steps in the [Contributing guide](https://github.com/TanStack/pacer/blob/main/CONTRIBUTING.md).

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).
